### PR TITLE
enable caching for the search dialog

### DIFF
--- a/src/dialogsearch.h
+++ b/src/dialogsearch.h
@@ -2,6 +2,8 @@
 #define DIALOGSEARCH_H
 
 #include <QDialog>
+#include <memory>
+#include <rpg_map.h>
 
 namespace Ui {
 class DialogSearch;
@@ -16,6 +18,7 @@ public:
     ~DialogSearch();
 
     void updateUI();
+    void enableCache(bool enable);
 
 private slots:
     void on_button_search_clicked();
@@ -23,8 +26,12 @@ private slots:
     void on_list_result_doubleClicked(const QModelIndex &index);
 
 private:
+    std::shared_ptr<RPG::Map> loadMap(int mapID);
+
     Ui::DialogSearch *ui;
     std::vector<std::tuple<int, int, int, int, std::vector<int>>> objectData;
+    std::vector<std::shared_ptr<RPG::Map>> map_cache;
+    bool useCache;
 };
 
 #endif // DIALOGSEARCH_H

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -89,7 +89,7 @@ static void associateFileTypes(const QStringList &fileTypes)
 MainWindow::MainWindow(QWidget *parent) :
     QMainWindow(parent),
     ui(new Ui::MainWindow),
-    searchdialog(nullptr)
+    searchdialog(new DialogSearch(this))
 {
     ui->setupUi(this);
     // Hide map ids
@@ -128,6 +128,7 @@ MainWindow::MainWindow(QWidget *parent) :
     updateLayerActions();
     updateToolActions();
     updateSearchUI();
+    searchdialog->enableCache(ui->actionEnable_Caching->isChecked());
 }
 
 MainWindow::~MainWindow()
@@ -150,6 +151,7 @@ void MainWindow::LoadLastProject()
     updateLayerActions();
     updateToolActions();
     updateSearchUI();
+    searchdialog->enableCache(ui->actionEnable_Caching->isChecked());
 }
 
 void MainWindow::LoadProject(QString foldername)
@@ -587,7 +589,7 @@ void MainWindow::on_action_New_Project_triggered()
         LMT_Reader::LoadXml(t_folder.toStdString()+EASY_MT);
         Data::treemap.maps[0].name = mCore->gameTitle().toStdString();
         /* Map */
-        RPG::Map map = *(LMU_Reader::LoadXml(t_folder.toStdString()+"Map0001.emu").get());
+        RPG::Map map = *LMU_Reader::LoadXml(t_folder.toStdString()+"Map0001.emu");
         /* DataBase */
         LDB_Reader::LoadXml(t_folder.toStdString()+EASY_DB);
         /* Save */
@@ -1281,18 +1283,12 @@ void MainWindow::on_actionMap_Properties_triggered()
 
 void MainWindow::on_actionSearch_triggered()
 {
-    if (!searchdialog)
-    {
-        searchdialog = new DialogSearch(this);
-        searchdialog->updateUI();
-    }
     searchdialog->setVisible(true);
 }
 
 void MainWindow::updateSearchUI()
 {
-    if (searchdialog)
-        searchdialog->updateUI();
+    searchdialog->updateUI();
 }
 
 void MainWindow::openScene(int mapID)
@@ -1309,4 +1305,9 @@ void MainWindow::selectTile(int x, int y)
 
         currentScene()->selectTile(x, y);
     }
+}
+
+void MainWindow::on_actionEnable_Caching_toggled(bool checked)
+{
+    searchdialog->enableCache(checked);
 }

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -117,6 +117,8 @@ private slots:
 
     void on_actionSearch_triggered();
 
+    void on_actionEnable_Caching_toggled(bool checked);
+
 private:
     void closeEvent(QCloseEvent *event);
     bool saveAll();

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -122,6 +122,7 @@
      <string>Debug</string>
     </property>
     <addaction name="actionRtp_Path"/>
+    <addaction name="actionEnable_Caching"/>
    </widget>
    <addaction name="menuGame"/>
    <addaction name="menuMaps"/>
@@ -927,6 +928,20 @@
    </property>
    <property name="toolTip">
     <string>Delete selected map.</string>
+   </property>
+  </action>
+  <action name="actionEnable_Caching">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Enable Caching</string>
+   </property>
+   <property name="toolTip">
+    <string>Enable caching in the searchdialog</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
Enable simple caching of parsed maps in the searchdialog. This will decrease the search time drastically. You also can disable this in the mainwindow with a tickbox.