### PR TITLE
Improve the search feature

### DIFF
--- a/src/dialogsearch.cpp
+++ b/src/dialogsearch.cpp
@@ -74,7 +74,7 @@ void DialogSearch::on_button_search_clicked()
                 {
                     auto& com = p.event_commands[line];
                     if (search_predicate(com))
-                        res.emplace_back(map.ID, e.ID, p.ID, line, com);
+                        res.emplace_back(map.ID, e.ID, p.ID, line+1, com);
                 }
 
         return res;
@@ -86,7 +86,7 @@ void DialogSearch::on_button_search_clicked()
             {
                 auto& com = e.event_commands[line];
                 if (search_predicate(com))
-                    res.emplace_back(0, e.ID, 0, line, com);
+                    res.emplace_back(0, e.ID, 0, line+1, com);
             }
 
         return res;

--- a/src/dialogsearch.cpp
+++ b/src/dialogsearch.cpp
@@ -107,7 +107,7 @@ void DialogSearch::on_button_search_clicked()
                 case Cmd::ControlVars:
                     return (com.parameters[4] == 1 && com.parameters[5] == varID) ||
                         (com.parameters[4] == 2 && com.parameters[5] == varID) ||
-                        com.parameters[0] == varID || com.parameters[1] == varID;
+                        com.parameters[1] == varID || com.parameters[2] == varID;
                 case Cmd::ChangeItems:
                 case Cmd::ChangePartyMembers:
                     return com.parameters[1] == 1 && com.parameters[2] == varID;

--- a/src/dialogsearch.cpp
+++ b/src/dialogsearch.cpp
@@ -94,7 +94,65 @@ void DialogSearch::on_button_search_clicked()
 
     if (ui->radio_variable->isChecked())
     {
-        //TODO implement me
+        int varID = ui->combo_variable->currentData().toInt();
+
+        search_predicate = [varID](const RPG::EventCommand& com)
+        {
+            switch (com.code)
+            {
+                case Cmd::InputNumber:
+                    return com.parameters[1] == varID;
+                case Cmd::ControlSwitches:
+                    return com.parameters[0] == 2 && com.parameters[1] == varID;
+                case Cmd::ControlVars:
+                    return (com.parameters[4] == 1 && com.parameters[5] == varID) ||
+                        (com.parameters[4] == 2 && com.parameters[5] == varID) ||
+                        com.parameters[0] == varID || com.parameters[1] == varID;
+                case Cmd::ChangeItems:
+                case Cmd::ChangePartyMembers:
+                    return com.parameters[1] == 1 && com.parameters[2] == varID;
+                case Cmd::EnemyEncounter:
+                    return com.parameters[0] == 1 && com.parameters[2] == varID;
+                case Cmd::ChangeSkills:
+                case Cmd::ChangeEquipment:
+                case Cmd::ChangeHP:
+                case Cmd::ChangeSP:
+                    return com.parameters[3] == 1 && com.parameters[4] == varID;
+                case Cmd::SimulatedAttack:
+                    return com.parameters[6] != 0 && com.parameters[7] == varID;
+                case Cmd::MemorizeLocation:
+                case Cmd::RecallToLocation:
+                    return com.parameters[0] == varID || com.parameters[1] == varID ||
+                        com.parameters[1] == varID;
+                case Cmd::SetVehicleLocation:
+                    return (com.parameters[1] == 1 && com.parameters[2] == varID) ||
+                        (com.parameters[1] == 1 && com.parameters[3] == varID) ||
+                        (com.parameters[1] == 1 && com.parameters[4] == varID);
+                case Cmd::ChangeEventLocation:
+                case Cmd::ShowPicture:
+                case Cmd::MovePicture:
+                    return (com.parameters[1] == 1 && com.parameters[2] == varID) ||
+                        (com.parameters[1] == 1 && com.parameters[3] == varID);
+                case Cmd::StoreTerrainID:
+                case Cmd::StoreEventID:
+                    return (com.parameters[1] == 1 && com.parameters[2] == varID) ||
+                        (com.parameters[1] == 1 && com.parameters[3] == varID) ||
+                        (com.parameters[1] == 1 && com.parameters[4] == varID);
+                case Cmd::KeyInputProc:
+                    return com.parameters[0] == varID ||
+                        (com.parameters.size() > 6 && com.parameters[7] == varID);
+                case Cmd::ConditionalBranch:
+                    return com.parameters[0] == 1 &&
+                        (com.parameters[1] == varID || (com.parameters[2] != 0 && com.parameters[3] == varID));
+                case Cmd::CallEvent:
+                    return com.parameters[0] == 2 && (com.parameters[1] == varID || com.parameters[2] == varID);
+                case Cmd::PlayMovie:
+                    return (com.parameters[0] == 1 && com.parameters[1] == varID) ||
+                        (com.parameters[0] == 1 && com.parameters[2] == varID);
+                default:
+                    return false;
+            }
+        };
     }
     else if (ui->radio_switch->isChecked())
     {

--- a/src/dialogsearch.cpp
+++ b/src/dialogsearch.cpp
@@ -36,13 +36,13 @@ void DialogSearch::updateUI()
     const QString format("%1: %2");
 
     for (auto &v : Data::variables)
-        ui->combo_variable->addItem(format.arg(QString::number(v.ID), QString::fromStdString(v.name)));
+        ui->combo_variable->addItem(format.arg(QString::number(v.ID), QString::fromStdString(v.name)), v.ID);
     for (auto &s : Data::switches)
-        ui->combo_switch->addItem(format.arg(QString::number(s.ID), QString::fromStdString(s.name)));
+        ui->combo_switch->addItem(format.arg(QString::number(s.ID), QString::fromStdString(s.name)), s.ID);
     for (auto &i : Data::items)
-        ui->combo_item->addItem(format.arg(QString::number(i.ID), QString::fromStdString(i.name)));
+        ui->combo_item->addItem(format.arg(QString::number(i.ID), QString::fromStdString(i.name)), i.ID);
     for (auto &e : Data::commonevents)
-        ui->combo_eventname->addItem(format.arg(QString::number(e.ID), QString::fromStdString(e.name)));
+        ui->combo_eventname->addItem(format.arg(QString::number(e.ID), QString::fromStdString(e.name)), e.ID);
 }
 
 void DialogSearch::enableCache(bool enable)
@@ -102,8 +102,7 @@ void DialogSearch::on_button_search_clicked()
     }
     else if (ui->radio_item->isChecked())
     {
-        QRegularExpression re("^(\\d+):?.*$");
-        int itemID = re.match(ui->combo_item->currentText()).captured(1).toInt();
+        int itemID = ui->combo_item->currentData().toInt();
 
         search_predicate = [itemID](const RPG::EventCommand& com)
         {

--- a/src/dialogsearch.cpp
+++ b/src/dialogsearch.cpp
@@ -156,7 +156,21 @@ void DialogSearch::on_button_search_clicked()
     }
     else if (ui->radio_switch->isChecked())
     {
-        //TODO implement me
+        int switchID = ui->combo_switch->currentData().toInt();
+
+        search_predicate = [switchID](const RPG::EventCommand& com)
+        {
+            switch(com.code)
+            {
+                case Cmd::ControlSwitches:
+                    return (com.parameters[0] != 2 && com.parameters[1] == switchID) ||
+                        (com.parameters[0] == 1 && com.parameters[2] == switchID);
+                case Cmd::ConditionalBranch:
+                    return com.parameters[0] == 0 && com.parameters[1] == switchID;
+                default:
+                    return false;
+            }
+        };
     }
     else if (ui->radio_item->isChecked())
     {

--- a/src/dialogsearch.h
+++ b/src/dialogsearch.h
@@ -6,7 +6,11 @@
 #include <rpg_map.h>
 
 namespace Ui {
-class DialogSearch;
+    class DialogSearch;
+}
+
+namespace RPG {
+    class EventCommand;
 }
 
 class DialogSearch : public QDialog
@@ -29,7 +33,8 @@ private:
     std::shared_ptr<RPG::Map> loadMap(int mapID);
 
     Ui::DialogSearch *ui;
-    std::vector<std::tuple<int, int, int, int, std::vector<int>>> objectData;
+    using command_info = std::tuple<int, int, int, int, const RPG::EventCommand&>; // map id, event id, page index, line, event command
+    std::vector<command_info> objectData;
     std::vector<std::shared_ptr<RPG::Map>> map_cache;
     bool useCache;
 };

--- a/src/dialogsearch.h
+++ b/src/dialogsearch.h
@@ -4,6 +4,7 @@
 #include <QDialog>
 #include <memory>
 #include <rpg_map.h>
+#include <vector>
 
 namespace Ui {
     class DialogSearch;
@@ -37,6 +38,7 @@ private:
     std::vector<command_info> objectData;
     std::vector<std::shared_ptr<RPG::Map>> map_cache;
     bool useCache;
+    void showResults(const std::vector<command_info>& results);
 };
 
 #endif // DIALOGSEARCH_H

--- a/src/stringizer.cpp
+++ b/src/stringizer.cpp
@@ -368,7 +368,7 @@ namespace
     QString stringizeChangeItems(const RPG::EventCommand& com)
     {
         return tr("Change Items") + ": "
-            + (com.parameters[0] ? "-" : "+")
+            + (com.parameters[0] ? "-" : "+") + " "
             + valueOrVariable(com.parameters[3], com.parameters[4])
             + (com.parameters[1] ? tr("Item") + " " + variable(com.parameters[2])
                                  : Stringizer::itemName(com.parameters[2]));

--- a/src/tools/qeventpagewidget.cpp
+++ b/src/tools/qeventpagewidget.cpp
@@ -84,7 +84,7 @@ void QEventPageWidget::setEventPage(RPG::EventPage *eventPage)
         const RPG::EventCommand& command = m_eventPage->event_commands[i];
         QTreeWidgetItem *item = new QTreeWidgetItem({Stringizer::stringize(command),
                                                      QString::number(m_codeGen)});
-        item->setToolTip(0, tr("Line") + ": " + QString::number(m_codeGen));
+        item->setToolTip(0, tr("Line") + ": " + QString::number(m_codeGen+1));
 
         if (command.code == Cmd::ShowChoiceOption && command.parameters[0] != 0)
             parent = parent->parent();


### PR DESCRIPTION
This conflicts #88 and #89.
The search now support search of variable and switches. The Action column now uses the Stringizer to format the output. 
![2016-09-12_17-02-44](https://cloud.githubusercontent.com/assets/4390703/18440814/c99b8144-790a-11e6-998a-a36018a534f8.png)
