### PR TITLE
Make Editor-Qt compile and work again

### DIFF
--- a/src/dialogsearch.cpp
+++ b/src/dialogsearch.cpp
@@ -74,7 +74,7 @@ void DialogSearch::on_button_search_clicked()
     ui->list_result->setHorizontalHeaderLabels(sl);
 
     std::function<bool(const RPG::EventCommand&)> search_predicate;
-    auto map_searcher = [&search_predicate](const RPG::Map& map) {
+    auto map_searcher = [&search_predicate](int mapID, const RPG::Map& map) {
         std::vector<command_info> res;
         for (auto& e : map.events)
             for (auto& p : e.pages)
@@ -82,7 +82,7 @@ void DialogSearch::on_button_search_clicked()
                 {
                     auto& com = p.event_commands[line];
                     if (search_predicate(com))
-                        res.emplace_back(map.ID, e.ID, p.ID, line+1, com);
+                        res.emplace_back(mapID, e.ID, p.ID, line+1, com);
                 }
 
         return res;
@@ -217,8 +217,7 @@ void DialogSearch::on_button_search_clicked()
         const auto mapID = static_cast<MainWindow*>(parent())->currentScene()->id();
         auto map = loadMap(mapID);
 
-        map->ID = mapID; // FIX: currently XML serialization is broken
-        auto res = map_searcher(*map);
+        auto res = map_searcher(mapID, *map);
         showResults(res);
     }
     else if (ui->scope_events->isChecked())
@@ -236,8 +235,7 @@ void DialogSearch::on_button_search_clicked()
 
             if (!mapp) continue;
 
-            mapp->ID = map.ID; // FIX: currently XML serialization is broken
-            auto res = map_searcher(*mapp);
+            auto res = map_searcher(map.ID, *mapp);
             showResults(res);
         }
     }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1104,7 +1104,6 @@ void MainWindow::on_actionNew_Map_triggered()
     {
         if (!m_treeItems.contains(i))
         {
-            map->ID = i;
             info.ID = i;
             info.name = tr("MAP%1").arg(QString::number(i),4, QLatin1Char('0')).toStdString();
             break;
@@ -1123,10 +1122,10 @@ void MainWindow::on_actionNew_Map_triggered()
 
     Data::treemap.maps.push_back(info);
     QTreeWidgetItem *item = new QTreeWidgetItem();
-    item->setData(1,Qt::DisplayRole,map->ID);
+    item->setData(1,Qt::DisplayRole,info.ID);
     item->setData(0,Qt::DisplayRole,QString::fromStdString(info.name));
     item->setIcon(0, QIcon(":/icons/share/old_map.png"));
-    m_treeItems[map->ID] = item;
+    m_treeItems[info.ID] = item;
     m_treeItems[info.parent_map]->addChild(item);
     QTreeWidgetItem *root = m_treeItems[0];
     QTreeWidgetItemIterator it(root);
@@ -1142,7 +1141,7 @@ void MainWindow::on_actionNew_Map_triggered()
     item->setSelected(true);
     LMT_Reader::SaveXml(mCore->filePath(ROOT, EASY_MT).toStdString());
     QString path = mCore->filePath(ROOT, "Map%1.emu");
-    path = path.arg(QString::number(map->ID), 4, QLatin1Char('0'));
+    path = path.arg(QString::number(info.ID), 4, QLatin1Char('0'));
     LMU_Reader::SaveXml(path.toStdString(), *map);
     on_treeMap_itemDoubleClicked(item, 0);
 }
@@ -1163,7 +1162,7 @@ void MainWindow::on_actionPaste_Map_triggered()
     RPG::MapInfo info;
     for (int i = 0; i < (int) Data::treemap.maps.size(); i++)
     {
-        if (Data::treemap.maps[i].ID == map->ID)
+        if (Data::treemap.maps[i].ID == info.ID)
         {
             info = Data::treemap.maps[i];
             break;
@@ -1175,7 +1174,6 @@ void MainWindow::on_actionPaste_Map_triggered()
     {
         if (!m_treeItems.contains(i))
         {
-            map->ID = i;
             info.ID = i;
             info.name = tr("MAP%1").arg(QString::number(i),4, QLatin1Char('0')).toStdString();
             break;
@@ -1199,10 +1197,10 @@ void MainWindow::on_actionPaste_Map_triggered()
 
     Data::treemap.maps.push_back(info);
     QTreeWidgetItem *item = new QTreeWidgetItem();
-    item->setData(1,Qt::DisplayRole,map->ID);
+    item->setData(1,Qt::DisplayRole,info.ID);
     item->setData(0,Qt::DisplayRole,QString::fromStdString(info.name));
     item->setIcon(0, QIcon(":/icons/share/old_map.png"));
-    m_treeItems[map->ID] = item;
+    m_treeItems[info.ID] = item;
     m_treeItems[info.parent_map]->addChild(item);
     QTreeWidgetItem *root = m_treeItems[0];
     QTreeWidgetItemIterator it(root);
@@ -1218,7 +1216,7 @@ void MainWindow::on_actionPaste_Map_triggered()
     item->setSelected(true);
     LMT_Reader::SaveXml(mCore->filePath(ROOT, EASY_MT).toStdString());
     QString path = mCore->filePath(ROOT, "Map%1.emu");
-    path = path.arg(QString::number(map->ID), 4, QLatin1Char('0'));
+    path = path.arg(QString::number(info.ID), 4, QLatin1Char('0'));
     LMU_Reader::SaveXml(path.toStdString(), *map);
     on_treeMap_itemDoubleClicked(item, 0);
 }


### PR DESCRIPTION
This patch makes the editor compilable again, and changes the template XML to a version that no longer hangs the editor when loading.

Fixes #96, #98, #99