### PR TITLE
New/import dialogs: set SetMinAndMaxSize constraint

### DIFF
--- a/src/dialogimportproject.ui
+++ b/src/dialogimportproject.ui
@@ -26,6 +26,9 @@
    <string>Import Project</string>
   </property>
   <layout class="QHBoxLayout" name="horizontalLayout_4">
+   <property name="sizeConstraint">
+    <enum>QLayout::SetMinAndMaxSize</enum>
+   </property>
    <item>
     <layout class="QVBoxLayout" name="verticalLayout">
      <item>

--- a/src/dialognewproject.ui
+++ b/src/dialognewproject.ui
@@ -26,6 +26,9 @@
    <string>Create new Project</string>
   </property>
   <layout class="QHBoxLayout" name="horizontalLayout_4">
+   <property name="sizeConstraint">
+    <enum>QLayout::SetMinAndMaxSize</enum>
+   </property>
    <item>
     <layout class="QVBoxLayout" name="verticalLayout">
      <item>


### PR DESCRIPTION
Just a minimal cosmetic change. Without this, the textboxes are too small on some systems.

Before:
![create-new-project](https://cloud.githubusercontent.com/assets/3201243/26078113/228b2656-39c7-11e7-8553-4a424cd00cec.png)

After:
![create-new-project-after](https://cloud.githubusercontent.com/assets/3201243/26078133/315aff3a-39c7-11e7-8ae5-cf6ae8c9ed73.png)
