### PR TITLE
Fix compiler warnings from Qt Creator

### DIFF
--- a/src/core.cpp
+++ b/src/core.cpp
@@ -23,7 +23,7 @@ Core::Core()
     m_lowerSelH = 1;
     m_upperSelH = 1;
     m_eventSel = 10000;
-    m_currentMapEvents = 0;
+    m_currentMapEvents = nullptr;
     m_dictionary[UPLEFT]                            = 1;
     m_dictionary[UPRIGHT]                           = 2;
     m_dictionary[UPLEFT+UPRIGHT]                    = 3;
@@ -72,7 +72,7 @@ Core::Core()
     m_dictionary[UP+DOWN+LEFT+RIGHT]                = 46;
     m_dictionary[SAMPLE]                            = 47;
 
-    m_runGameDialog = 0;
+    m_runGameDialog = nullptr;
 }
 
 Core *Core::getCore()
@@ -240,36 +240,36 @@ void Core::LoadChipset(int n_chipsetid)
         //Draw LowerRight corner
         dest_y = tileSize()/2;
         if (d+r == 10)
-            blit(border_xoffset+r_tileHalf, 0.5*r_tileSize);
+            blit(border_xoffset+r_tileHalf, r_tileSize/2);
         else if (d)
-            blit(border_xoffset+r_tileHalf, 2.5*r_tileSize);
+            blit(border_xoffset+r_tileHalf, r_tileSize*5/2);
         else if (r)
-            blit(border_xoffset+r_tileHalf, 1.5*r_tileSize);
+            blit(border_xoffset+r_tileHalf, r_tileSize*3/2);
         else if (dr)
-            blit(border_xoffset+r_tileHalf, 3.5*r_tileSize);
+            blit(border_xoffset+r_tileHalf, r_tileSize*7/2);
         else if (sdr)
         {
             if (isABWater (terrain_id))
-                blit(tileSize()/2, 5.5*r_tileSize);
+                blit(tileSize()/2, r_tileSize*11/2);
             else
-                blit(tileSize()/2, 6.5*r_tileSize);
+                blit(tileSize()/2, r_tileSize*13/2);
         }
         //Draw LowerLeft corner
         dest_x = 0;
         if (d+l == 6)
-            blit(border_xoffset, 0.5*r_tileSize);
+            blit(border_xoffset, r_tileSize/2);
         else if (d)
-            blit(border_xoffset, 2.5*r_tileSize);
+            blit(border_xoffset, r_tileSize*5/2);
         else if (l)
-            blit(border_xoffset, 1.5*r_tileSize);
+            blit(border_xoffset, r_tileSize*3/2);
         else if (dl)
-            blit(border_xoffset, 3.5*r_tileSize);
+            blit(border_xoffset, r_tileSize*7/2);
         else if (sdl)
         {
             if (isABWater (terrain_id))
-                blit(0, 5.5*r_tileSize);
+                blit(0, r_tileSize*11/2);
             else
-                blit(0, 6.5*r_tileSize);
+                blit(0, r_tileSize*13/2);
         }
 #undef blit
         m_tileCache[id] = p_tile;
@@ -388,33 +388,33 @@ void Core::LoadChipset(int n_chipsetid)
              */
             dest_x = tileSize()/2;
             if (u+r == 9)
-                blit(r_tileSize*2.5, r_tileSize);
+                blit(r_tileSize*5/2, r_tileSize);
             else if (u)
             {
                 if(l)
-                    blit(r_tileSize*0.5, r_tileSize);
+                    blit(r_tileSize/2, r_tileSize);
                 else
-                    blit(r_tileSize*1.5, r_tileSize);
+                    blit(r_tileSize*3/2, r_tileSize);
             }
             else if (r)
             {
                 if (d)
-                    blit(r_tileSize*2.5, r_tileSize*3);
+                    blit(r_tileSize*5/2, r_tileSize*3);
                 else
-                    blit(r_tileSize*2.5, r_tileSize*2);
+                    blit(r_tileSize*5/2, r_tileSize*2);
             }
             else if (ur)
-                blit(r_tileSize*2.5, 0);
+                blit(r_tileSize*5/2, 0);
             else //0
             {
                 if (d+l == 6)
-                    blit(r_tileSize*0.5, r_tileSize*3);
+                    blit(r_tileSize/2, r_tileSize*3);
                 else if (l)
-                    blit(r_tileSize*0.5, r_tileSize*2);
+                    blit(r_tileSize/2, r_tileSize*2);
                 else if (d)
-                    blit(r_tileSize*1.5, r_tileSize*3);
+                    blit(r_tileSize*3/2, r_tileSize*3);
                 else
-                    blit(r_tileSize*1.5, r_tileSize*2);
+                    blit(r_tileSize*3/2, r_tileSize*2);
             }
             /*
              * Draw down_left corner
@@ -422,66 +422,66 @@ void Core::LoadChipset(int n_chipsetid)
             dest_x = 0;
             dest_y = tileSize()/2;
             if (d+l == 6)
-                blit(0, r_tileSize*3.5);
+                blit(0, r_tileSize*7/2);
             else if (d)
             {
                 if (r)
-                    blit(r_tileSize*2, r_tileSize*3.5);
+                    blit(r_tileSize*2, r_tileSize*7/2);
                 else
-                    blit(r_tileSize, r_tileSize*3.5);
+                    blit(r_tileSize, r_tileSize*7/2);
             }
             else if (l)
             {
                 if (u)
-                    blit(0, r_tileSize*1.5);
+                    blit(0, r_tileSize*3/2);
                 else
-                    blit(0, r_tileSize*2.5);
+                    blit(0, r_tileSize*5/2);
             }
             else if (dl)
                 blit(r_tileSize*2, r_tileHalf);
             else
             {
                 if (u+r == 9)
-                    blit(r_tileSize*2, r_tileSize*1.5);
+                    blit(r_tileSize*2, r_tileSize*3/2);
                 else if (r)
-                    blit(r_tileSize*2, r_tileSize*2.5);
+                    blit(r_tileSize*2, r_tileSize*5/2);
                 else if (u)
-                    blit(r_tileSize, r_tileSize*1.5);
+                    blit(r_tileSize, r_tileSize*3/2);
                 else
-                    blit(r_tileSize, r_tileSize*2.5);
+                    blit(r_tileSize, r_tileSize*5/2);
             }
             /*
              * Draw down_right corner
              */
             dest_x = tileSize()/2;
             if (d+r == 10)
-                blit(r_tileSize*2.5, r_tileSize*3.5);
+                blit(r_tileSize*5*2, r_tileSize*7/2);
             else if (d)
             {
                 if (l)
-                    blit(r_tileSize*0.5, r_tileSize*3.5);
+                    blit(r_tileSize/2, r_tileSize*7/2);
                 else
-                    blit(r_tileSize*1.5, r_tileSize*3.5);
+                    blit(r_tileSize*3/2, r_tileSize*7/2);
             }
             else if (r)
             {
                 if (u)
-                    blit(r_tileSize*2.5, r_tileSize*1.5);
+                    blit(r_tileSize*5/2, r_tileSize*3/2);
                 else
-                    blit(r_tileSize*2.5, r_tileSize*2.5);
+                    blit(r_tileSize*5/2, r_tileSize*5/2);
             }
             else if (dr)
-                blit(r_tileSize*2.5, r_tileHalf);
+                blit(r_tileSize*5/2, r_tileHalf);
             else //0
             {
                 if (u+l == 5)
-                    blit(r_tileHalf,r_tileSize*1.5);
+                    blit(r_tileHalf,r_tileSize*3/2);
                 else if (l)
-                    blit(r_tileHalf,r_tileSize*2.5);
+                    blit(r_tileHalf,r_tileSize*5/2);
                 else if (u)
-                    blit(r_tileSize*1.5,r_tileSize*1.5);
+                    blit(r_tileSize*3/2,r_tileSize*3/2);
                 else
-                    blit(r_tileSize*1.5,r_tileSize*2.5);
+                    blit(r_tileSize*3/2,r_tileSize*5/2);
             }
 #undef blit
             /*
@@ -693,7 +693,7 @@ void Core::renderEvent(const RPG::Event& event, const QRect &dest_rect)
     QRect final_rect = dest_rect.adjusted(fact/6,fact/6,-fact/6,-fact/6);
     m_painter.drawRect(final_rect.adjusted(-1,-1,0,0));
     if (event.pages[0].character_name.empty())
-        renderTile(event.pages[0].character_index+10000, final_rect);
+        renderTile(static_cast<short>(event.pages[0].character_index+10000), final_rect);
     else {
         if (!m_eventCache.contains(event.ID))
             return;
@@ -716,15 +716,15 @@ short Core::translate(int terrain_id, int _code, int _scode)
     if (terrain_id < 0)
         return 0x7FFF;
     if (isWater(terrain_id))
-        return (terrain_id*1000+m_dictionary[_code]+m_dictionary[_scode]*50);
+        return (static_cast<short>(terrain_id)*1000+m_dictionary[_code]+m_dictionary[_scode]*50);
     if (isAnimation(terrain_id))
-        return (3000+(terrain_id-3)*50+46);
+        return (3000+(static_cast<short>(terrain_id)-3)*50+46);
     if (isDblock(terrain_id))
-        return (4000+(terrain_id-6)*50+m_dictionary[_code]);
+        return (4000+(static_cast<short>(terrain_id)-6)*50+m_dictionary[_code]);
     if (isEblock(terrain_id))
-        return (5000+terrain_id-18);
+        return (5000+static_cast<short>(terrain_id)-18);
     if (isFblock(terrain_id))
-        return (10000+terrain_id-162);
+        return (10000+static_cast<short>(terrain_id)-162);
     return 0x7FFF;
 }
 
@@ -764,7 +764,7 @@ short Core::selection(int off_x, int off_y)
             off_x += m_lowerSelW;
         if (off_y < 0)
             off_y += m_lowerSelH;
-        result = m_lowerSel[off_x+off_y*m_lowerSelW];
+        result = m_lowerSel[static_cast<size_t>(off_x+off_y*m_lowerSelW)];
         break;
     case UPPER:
         off_x %= m_upperSelW;
@@ -773,7 +773,7 @@ short Core::selection(int off_x, int off_y)
             off_x += m_upperSelW;
         if (off_y < 0)
             off_y += m_upperSelH;
-        result = m_upperSel[off_x+off_y*m_upperSelW];
+        result = m_upperSel[static_cast<size_t>(off_x+off_y*m_upperSelW)];
         break;
     case EVENT:
         result = m_eventSel;
@@ -804,7 +804,7 @@ int Core::selHeight()
 
 void Core::setSelection(std::vector<short> n_sel, int n_w, int n_h)
 {
-    if ((int) n_sel.size() != n_w * n_h)
+    if (static_cast<int>(n_sel.size()) != n_w * n_h)
         return;
     switch(m_layer)
     {
@@ -826,7 +826,7 @@ void Core::setSelection(std::vector<short> n_sel, int n_w, int n_h)
 
 RPG::Event *Core::currentMapEvent(int eventID)
 {
-    RPG::Event *event = 0;
+    RPG::Event *event = nullptr;
     if (m_currentMapEvents)
         event = m_currentMapEvents->value(eventID);
     if (!event)

--- a/src/dialogdatabase.cpp
+++ b/src/dialogdatabase.cpp
@@ -11,8 +11,8 @@ DialogDataBase::DialogDataBase(QWidget *parent) :
 {
     ui->setupUi(this);
     m_data = Data::data;
-    m_currentActor = 0;
-    on_currentActorChanged(0);
+    m_currentActor = nullptr;
+    on_currentActorChanged(nullptr);
     Old_PageActors = new QDbPageActors(m_data, this);
     Old_PageClasses = new QDbPageClasses(m_data, this);
     Old_PageSkills= new QDbPageSkills(m_data, this);
@@ -65,7 +65,7 @@ DialogDataBase::~DialogDataBase()
 void DialogDataBase::on_currentActorChanged(RPG::Actor *actor)
 {
     m_currentActor = actor;
-    if (actor == 0){
+    if (actor == nullptr){
         /* Clear Table */
         for (int i = 0; i < ui->tableNew_CharacterProperties->rowCount(); i++)
             ui->tableNew_CharacterProperties->item(i,1)->setText("");
@@ -88,9 +88,9 @@ void DialogDataBase::on_currentActorChanged(RPG::Actor *actor)
     ui->tableNew_CharacterProperties->item(8,1)->setText(actor->auto_battle ? yes :no);
     ui->tableNew_CharacterProperties->item(9,1)->setText(actor->super_guard ? yes :no);
     ui->tableNew_CharacterProperties->item(10,1)->setText(actor->class_id < 1 ? tr("<none>") :
-                                                          actor->class_id >= (int)m_data.classes.size() ?
+                                                          actor->class_id >= static_cast<int>(m_data.classes.size()) ?
                                                           tr("<%1?>").arg(actor->class_id) :
-                                                          m_data.classes[actor->class_id-1].name.c_str());
+                                                          m_data.classes[static_cast<size_t>(actor->class_id)-1].name.c_str());
     ui->tableNew_CharacterProperties->item(11,1)->setText(QString("%1[%2]")
                                                           .arg(actor->face_name.c_str())
                                                           .arg(actor->face_index));
@@ -99,9 +99,9 @@ void DialogDataBase::on_currentActorChanged(RPG::Actor *actor)
                                                           .arg(actor->character_index)
                                                           .arg(actor->transparent ? " [Transparent]" : ""));
     ui->tableNew_CharacterProperties->item(13,1)->setText(actor->battler_animation < 1 ? tr("<none>") :
-                                                          actor->battler_animation >= (int)m_data.battleranimations.size() ?
+                                                          actor->battler_animation >= static_cast<int>(m_data.battleranimations.size()) ?
                                                           tr("<%1?>").arg(actor->battler_animation) :
-                                                          m_data.battleranimations[actor->battler_animation-1].name.c_str());
+                                                          m_data.battleranimations[static_cast<size_t>(actor->battler_animation) - 1].name.c_str());
 
     /* TODO: fill the following information */
     ui->tableNew_CharacterProperties->item(14,1)->setText("Click to Edit");
@@ -133,7 +133,7 @@ void DialogDataBase::on_tabOld_Pages_currentChanged(int index)
 
 void DialogDataBase::on_toolSwitchStyle_clicked(bool checked)
 {
-    ui->stackedStyle->setCurrentIndex((int)checked);
+    ui->stackedStyle->setCurrentIndex(static_cast<int>(checked));
 }
 
 void DialogDataBase::on_buttonBox_clicked(QAbstractButton *button)
@@ -165,13 +165,13 @@ void DialogDataBase::on_lineNew_CharacterFilter_textChanged(const QString &arg1)
 
 void DialogDataBase::on_listNew_Character_currentRowChanged(int currentRow)
 {
-    if (currentRow < 0 || currentRow >= (int)m_data.actors.size())
+    if (currentRow < 0 || currentRow >= static_cast<int>(m_data.actors.size()))
     {
-        on_currentActorChanged(0);
-        emit currentActorChanged(0);
+        on_currentActorChanged(nullptr);
+        emit currentActorChanged(nullptr);
         return; //invalid
     }
 
-    on_currentActorChanged(&m_data.actors[currentRow]);
-    emit currentActorChanged(&m_data.actors[currentRow]);
+    on_currentActorChanged(&m_data.actors[static_cast<size_t>(currentRow)]);
+    emit currentActorChanged(&m_data.actors[static_cast<size_t>(currentRow)]);
 }

--- a/src/dialogdatabase.h
+++ b/src/dialogdatabase.h
@@ -33,7 +33,7 @@ class DialogDataBase : public QDialog
     Q_OBJECT
     
 public:
-    explicit DialogDataBase(QWidget *parent = 0);
+    explicit DialogDataBase(QWidget *parent = nullptr);
     ~DialogDataBase();
 
 signals:

--- a/src/dialogevent.cpp
+++ b/src/dialogevent.cpp
@@ -32,7 +32,7 @@ int DialogEvent::edit(QWidget *parent, RPG::Event *event)
     dlg.setEvent(event);
     dlg.exec();
     if (dlg.lst_result != QDialogButtonBox::Cancel)
-        *event = dlg.event();
+        *event = dlg.getEvent();
     return dlg.lst_result;
 }
 
@@ -100,7 +100,7 @@ bool DialogEvent::equalEvents(const RPG::Event &e1, const RPG::Event &e2)
 #undef chk
 }
 
-RPG::Event DialogEvent::event() const
+RPG::Event DialogEvent::getEvent() const
 {
     switch(lst_result)
     {

--- a/src/dialogevent.h
+++ b/src/dialogevent.h
@@ -13,7 +13,7 @@ class DialogEvent : public QDialog
     Q_OBJECT
 
 public:
-    explicit DialogEvent(QWidget *parent = 0);
+    explicit DialogEvent(QWidget *parent = nullptr);
     ~DialogEvent();
 
     static int edit(QWidget *parent, RPG::Event *event);
@@ -21,7 +21,7 @@ public:
     static bool equalEvents(const RPG::Event &e1,
                             const RPG::Event &e2);
 
-    RPG::Event event() const;
+    RPG::Event getEvent() const;
     void setEvent(RPG::Event *event);
 
 private slots:

--- a/src/dialogimportimage.cpp
+++ b/src/dialogimportimage.cpp
@@ -44,7 +44,7 @@ void DialogImportImage::on_pushZoomIn_clicked()
     m_scale += 1.0;
     ui->graphicsView->resetTransform();
     ui->graphicsView->scale(m_scale,m_scale);
-    if (m_scale == 4)
+    if (static_cast<int>(m_scale) == 4)
         ui->pushZoomIn->setEnabled(false);
     ui->pushZoomOut->setEnabled(true);
 
@@ -55,7 +55,7 @@ void DialogImportImage::on_pushZoomOut_clicked()
     m_scale -= 1.0;
     ui->graphicsView->resetTransform();
     ui->graphicsView->scale(m_scale,m_scale);
-    if (m_scale == 1)
+    if (static_cast<int>(m_scale) == 1)
         ui->pushZoomOut->setEnabled(false);
     ui->pushZoomIn->setEnabled(true);
 }

--- a/src/dialogimportimage.h
+++ b/src/dialogimportimage.h
@@ -15,7 +15,7 @@ class DialogImportImage : public QDialog
     Q_OBJECT
     
 public:
-    explicit DialogImportImage(QString n_filepath, QWidget *parent = 0);
+    explicit DialogImportImage(QString n_filepath, QWidget *parent = nullptr);
     ~DialogImportImage();
 
     QImage image();

--- a/src/dialogimportproject.h
+++ b/src/dialogimportproject.h
@@ -12,7 +12,7 @@ class DialogImportProject : public QDialog
     Q_OBJECT
 
 public:
-    explicit DialogImportProject(QWidget *parent = 0);
+    explicit DialogImportProject(QWidget *parent = nullptr);
     ~DialogImportProject();
 
     void setDefDir(QString n_defDir);

--- a/src/dialogmapproperties.cpp
+++ b/src/dialogmapproperties.cpp
@@ -30,8 +30,8 @@ DialogMapProperties::DialogMapProperties(RPG::MapInfo &info, RPG::Map &map, QWid
     ui->lineName->setText(QString::fromStdString(info.name));
     ui->lineBGMname->setText(QString::fromStdString(info.music.name));
     ui->lineBackdropName->setText(QString::fromStdString(info.background_name));
-    for (int i = 0; i < (int)Data::chipsets.size(); i++)
-        ui->comboTileset->addItem(QString::fromStdString(Data::chipsets[i].name), i+1);
+    for (int i = 0; i < static_cast<int>(Data::chipsets.size()); i++)
+        ui->comboTileset->addItem(QString::fromStdString(Data::chipsets[static_cast<size_t>(i)].name), i+1);
     ui->comboTileset->setCurrentIndex(map.chipset_id-1);
     ui->comboWrapping->setCurrentIndex(map.scroll_type);
     ui->spinDungeonRoomHeight->setValue(map.generator_height);
@@ -69,11 +69,11 @@ DialogMapProperties::DialogMapProperties(RPG::MapInfo &info, RPG::Map &map, QWid
     ui->radioDungeonOpenRoom->setChecked(map.generator_mode == 3);
     ui->radioDungeonPassage1_1->setChecked(map.generator_tiles == 0);
     ui->radioDungeonPassage2_2->setChecked(map.generator_tiles == 1);
-    for (int i = (int)info.encounters.size() - 1; i >= 0; i--)
+    for (int i = static_cast<int>(info.encounters.size()) - 1; i >= 0; i--)
     {
         QTableWidgetItem * item = new QTableWidgetItem();
-        item->setData(Qt::DisplayRole, QString::fromStdString(Data::troops[info.encounters[i].troop_id-1].name));
-        item->setData(Qt::UserRole, info.encounters[i].troop_id);
+        item->setData(Qt::DisplayRole, QString::fromStdString(Data::troops[static_cast<size_t>(info.encounters[static_cast<size_t>(i)].troop_id)-1].name));
+        item->setData(Qt::UserRole, info.encounters[static_cast<size_t>(i)].troop_id);
         ui->tableEncounters->insertRow(0);
         ui->tableEncounters->setItem(0,0,item);
     }

--- a/src/dialogmapproperties.h
+++ b/src/dialogmapproperties.h
@@ -17,7 +17,7 @@ class DialogMapProperties : public QDialog
     Q_OBJECT
 
 public:
-    explicit DialogMapProperties(RPG::MapInfo &info, RPG::Map &map, QWidget *parent = 0);
+    explicit DialogMapProperties(RPG::MapInfo &info, RPG::Map &map, QWidget *parent = nullptr);
     ~DialogMapProperties();
 
 private slots:

--- a/src/dialognewproject.h
+++ b/src/dialognewproject.h
@@ -12,7 +12,7 @@ class DialogNewProject : public QDialog
     Q_OBJECT
     
 public:
-    explicit DialogNewProject(QWidget *parent = 0);
+    explicit DialogNewProject(QWidget *parent = nullptr);
     ~DialogNewProject();
 
     QString getGameTitle() const;

--- a/src/dialogopenproject.h
+++ b/src/dialogopenproject.h
@@ -12,7 +12,7 @@ class DialogOpenProject : public QDialog
     Q_OBJECT
 
 public:
-    explicit DialogOpenProject(QWidget *parent = 0);
+    explicit DialogOpenProject(QWidget *parent = nullptr);
     ~DialogOpenProject();
 
     void setDefDir(QString n_defDir);

--- a/src/dialogresourcemanager.h
+++ b/src/dialogresourcemanager.h
@@ -13,7 +13,7 @@ class DialogResourceManager : public QDialog
     Q_OBJECT
     
 public:
-    explicit DialogResourceManager(QWidget *parent = 0);
+    explicit DialogResourceManager(QWidget *parent = nullptr);
     ~DialogResourceManager();
 
 private slots:

--- a/src/dialogrtppath.h
+++ b/src/dialogrtppath.h
@@ -12,7 +12,7 @@ class DialogRtpPath : public QDialog
     Q_OBJECT
 
 public:
-    explicit DialogRtpPath(QWidget *parent = 0);
+    explicit DialogRtpPath(QWidget *parent = nullptr);
     ~DialogRtpPath();
 
 private slots:

--- a/src/dialogrungame.cpp
+++ b/src/dialogrungame.cpp
@@ -75,7 +75,7 @@ void DialogRunGame::UpdateModels()
 {
     // Maps
     ui->comboMapId->clear();
-    for (int i = 1; i < (int)Data::treemap.maps.size(); i++)
+    for (size_t i = 1; i < Data::treemap.maps.size(); i++)
     {
         if (Data::treemap.maps[i].type == 1)
         {
@@ -87,10 +87,10 @@ void DialogRunGame::UpdateModels()
     // Troops
     ui->comboTroop->clear();
     ui->comboTroop->addItem(tr("<Test Troop>"));
-    for (int i = 1; i < (int)Data::troops.size(); i++)
+    for (size_t i = 1; i < Data::troops.size(); i++)
         ui->comboTroop->addItem(QString::fromStdString(Data::troops[i].name));
 
-    bool auto_placement = (bool)Data::data.battlecommands.placement;
+    bool auto_placement = static_cast<bool>(Data::data.battlecommands.placement);
     ui->groupPartyFormation->setEnabled(auto_placement);
     ui->comboBattleCondition->clear();
     QStringList conditions;
@@ -100,12 +100,12 @@ void DialogRunGame::UpdateModels()
     ui->comboBattleCondition->addItems(conditions);
 
     ui->comboCustomFormation->clear();
-    for (int i = 0; i < (int)Data::terrains.size(); i++)
+    for (size_t i = 0; i < Data::terrains.size(); i++)
         ui->comboCustomFormation->addItem(QString::fromStdString(Data::terrains[i].name));
 
     battletest_data = Data::system.battletest_data;
-    for (int i = 0; i < (int)battletest_data.size(); i++)
-        ui->tableInitialParty->item(i,0)->setData(Qt::UserRole, battletest_data[i].actor_id);
+    for (size_t i = 0; i < battletest_data.size(); i++)
+        ui->tableInitialParty->item(static_cast<int>(i),0)->setData(Qt::UserRole, battletest_data[i].actor_id);
 }
 
 void DialogRunGame::on_tableInitialParty_itemChanged(QTableWidgetItem *item)

--- a/src/dialogrungame.h
+++ b/src/dialogrungame.h
@@ -15,7 +15,7 @@ class DialogRunGame : public QDialog
 
 public:
 
-    explicit DialogRunGame(QWidget *parent = 0);
+    explicit DialogRunGame(QWidget *parent = nullptr);
     ~DialogRunGame();
 
     void runHere(int map_id, int x, int y);

--- a/src/dialogsearch.cpp
+++ b/src/dialogsearch.cpp
@@ -245,26 +245,26 @@ void DialogSearch::on_button_search_clicked()
 void DialogSearch::on_list_result_doubleClicked(const QModelIndex &index)
 {
     auto *par = static_cast<MainWindow*>(parent());
-    par->openScene(std::get<0>(objectData[index.row()]));
-    auto *event = (*par->currentScene()->mapEvents())[std::get<1>(objectData[index.row()])];
+    par->openScene(std::get<0>(objectData[static_cast<size_t>(index.row())]));
+    auto *event = (*par->currentScene()->mapEvents())[std::get<1>(objectData[static_cast<size_t>(index.row())])];
     par->selectTile(event->x, event->y);
     par->currentScene()->centerOnTile(event->x, event->y);
 }
 
 std::shared_ptr<RPG::Map> DialogSearch::loadMap(int mapID)
 {
-    if (!(useCache && map_cache[mapID]))
+    if (!(useCache && map_cache[static_cast<size_t>(mapID)]))
     {
         const QString file = QString("Map%1.emu").arg(QString::number(mapID), 4, QLatin1Char('0'));
         const std::shared_ptr<RPG::Map> res_map{LMU_Reader::LoadXml(mCore->filePath(ROOT, file).toStdString())};
 
         if (useCache)
-            map_cache[mapID] = res_map;
+            map_cache[static_cast<size_t>(mapID)] = res_map;
 
         return res_map;
     }
 
-    return map_cache[mapID];
+    return map_cache[static_cast<size_t>(mapID)];
 }
 
 void DialogSearch::showResults(const std::vector<command_info>& results) {
@@ -284,7 +284,7 @@ void DialogSearch::showResults(const std::vector<command_info>& results) {
         {
             do
             {
-                auto& mapinfo = Data::treemap.maps[mm];
+                auto& mapinfo = Data::treemap.maps[static_cast<size_t>(mm)];
                 maps_rev << QString::fromStdString(mapinfo.name);
                 mm = mapinfo.parent_map;
             } while (mm != 0);

--- a/src/dialogsearch.h
+++ b/src/dialogsearch.h
@@ -19,7 +19,7 @@ class DialogSearch : public QDialog
     Q_OBJECT
 
 public:
-    explicit DialogSearch(QWidget *parent = 0);
+    explicit DialogSearch(QWidget *parent = nullptr);
     ~DialogSearch();
 
     void updateUI();

--- a/src/dialogsplash.h
+++ b/src/dialogsplash.h
@@ -14,7 +14,7 @@ class DialogSplash : public QDialog
     Q_OBJECT
 
 public:
-    explicit DialogSplash(QWidget *parent = 0);
+    explicit DialogSplash(QWidget *parent = nullptr);
     ~DialogSplash();
 
 private:

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -21,7 +21,7 @@ class MainWindow : public QMainWindow
     Q_OBJECT
     
 public:
-    explicit MainWindow(QWidget *parent = 0);
+    explicit MainWindow(QWidget *parent = nullptr);
     ~MainWindow();
 
     void LoadLastProject();

--- a/src/musicplayer.cpp
+++ b/src/musicplayer.cpp
@@ -51,19 +51,19 @@
 
 MusicPlayer::MusicPlayer(QWidget *parent) : QWidget(parent),
 #ifdef Q_OS_WIN
-    taskbarButton(0),
-    taskbarProgress(0),
-    thumbnailToolBar(0),
-    playToolButton(0),
-    forwardToolButton(0),
-    backwardToolButton(0),
+    taskbarButton(nullptr),
+    taskbarProgress(nullptr),
+    thumbnailToolBar(nullptr),
+    playToolButton(nullptr),
+    forwardToolButton(nullptr),
+    backwardToolButton(nullptr),
 #endif
-    mediaPlayer(0),
-    playButton(0),
-    volumeButton(0),
-    positionSlider(0),
-    positionLabel(0),
-    infoLabel(0)
+    mediaPlayer(nullptr),
+    playButton(nullptr),
+    volumeButton(nullptr),
+    positionSlider(nullptr),
+    positionLabel(nullptr),
+    infoLabel(nullptr)
 {
     createWidgets();
     createShortcuts();
@@ -184,17 +184,17 @@ void MusicPlayer::updateState(QMediaPlayer::State state)
 
 void MusicPlayer::updatePosition(qint64 position)
 {
-    positionSlider->setValue(position);
+    positionSlider->setValue(static_cast<int>(position));
 
-    QTime duration(0, position / 60000, qRound((position % 60000) / 1000.0));
+    QTime duration(0, static_cast<int>(position / 60000), qRound((position % 60000) / 1000.0));
     positionLabel->setText(duration.toString(tr("mm:ss")));
 }
 
 void MusicPlayer::updateDuration(qint64 duration)
 {
-    positionSlider->setRange(0, duration);
+    positionSlider->setRange(0, static_cast<int>(duration));
     positionSlider->setEnabled(duration > 0);
-    positionSlider->setPageStep(duration / 10);
+    positionSlider->setPageStep(static_cast<int>(duration / 10));
 }
 
 void MusicPlayer::setPosition(int position)

--- a/src/musicplayer.h
+++ b/src/musicplayer.h
@@ -60,7 +60,7 @@ class MusicPlayer : public QWidget
 {
     Q_OBJECT
 public:
-    MusicPlayer(QWidget *parent = 0);
+    MusicPlayer(QWidget *parent = nullptr);
 
 public slots:
     void openFile();

--- a/src/stringizer.cpp
+++ b/src/stringizer.cpp
@@ -563,10 +563,10 @@ namespace
             };
 
         QString context;
-        if (com.parameters[0] < 0 || com.parameters[0] >= (int)bgm_contexts.size())
+        if (com.parameters[0] < 0 || com.parameters[0] >= static_cast<int>(bgm_contexts.size()))
             context = tr("Unknown");
         else
-            context = bgm_contexts[com.parameters[0]];
+            context = bgm_contexts[static_cast<size_t>(com.parameters[0])];
         return tr("Change System BGM") + ": " + context + ", "
             + QString::fromStdString(com.string);
     }
@@ -589,10 +589,10 @@ namespace
                 tr("Use Item")
             };
         QString sfx;
-        if (com.parameters[0] < 0 || com.parameters[0] >= (int)system_sfx.size())
+        if (com.parameters[0] < 0 || com.parameters[0] >= static_cast<int>(system_sfx.size()))
             sfx = tr("Unknown");
         else
-            sfx = system_sfx[com.parameters[0]];
+            sfx = system_sfx[static_cast<size_t>(com.parameters[0])];
         return tr("Change System SFX") + ": " + sfx + ", "
             + QString::fromStdString(com.string);
     }
@@ -622,12 +622,13 @@ namespace
         switch (com.parameters[0])
         {
             case 0:
-                buysell = tr("Buy") + "/" + tr("Sell"); break;
+                buysell = tr("Buy") + "/" + tr("Sell");
+                break;
             case 1:
                 buysell = tr("Buy");
+                break;
             case 2:
                 buysell = tr("Sell");
-
         }
         return tr("Open Shop") + ": " + buysell;
     }
@@ -880,7 +881,7 @@ namespace
     QString stringizeMoveEvent(const RPG::EventCommand& com)
     {
         QString movements;
-        for (int i = 4; i < 8 && i < (int)com.parameters.size(); ++i)
+        for (size_t i = 4; i < 8 && i < com.parameters.size(); ++i)
             movements.append(", ").append(Stringizer::moveCommand(com.parameters[i]));
         if (com.parameters.size() >= 8)
             movements.append("...");
@@ -1079,6 +1080,7 @@ namespace
             break;
         case 9: // BGM looped at least once
             condition = tr("BGM has Played Through Once");
+            break;
         case 10: // Timer 2
             condition = tr("Timer") + "2 "
                 + (com.parameters[2] ? "<=" : ">=") + " "
@@ -1193,72 +1195,72 @@ namespace Stringizer
 {
     QString varName(int id)
     {
-        if (id < 1 || id > (int)Data::variables.size())
+        if (id < 1 || id > static_cast<int>(Data::variables.size()))
             return QString("<%1?>").arg(id);
-        return QString::fromStdString(Data::variables[id-1].name);
+        return QString::fromStdString(Data::variables[static_cast<size_t>(id)-1].name);
     }
 
     QString switchName(int id)
     {
-        if (id < 1 || id > (int)Data::switches.size())
+        if (id < 1 || id > static_cast<int>(Data::switches.size()))
             return QString("<%1?>").arg(id);
-        return QString::fromStdString(Data::switches[id-1].name);
+        return QString::fromStdString(Data::switches[static_cast<size_t>(id) - 1].name);
     }
 
     QString itemName(int id)
     {
-        if (id < 1 || id > (int)Data::items.size())
+        if (id < 1 || id > static_cast<int>(Data::items.size()))
             return QString("<%1?>").arg(id);
-        return QString::fromStdString(Data::items[id-1].name);
+        return QString::fromStdString(Data::items[static_cast<size_t>(id)-1].name);
     }
 
     QString heroName(int id)
     {
-        if (id < 1 || id > (int)Data::actors.size())
+        if (id < 1 || id > static_cast<int>(Data::actors.size()))
             return QString("<%1?>").arg(id);
-        return QString::fromStdString(Data::actors[id-1].name);
+        return QString::fromStdString(Data::actors[static_cast<size_t>(id)-1].name);
     }
 
     QString className(int id)
     {
-        if (id < 1 || id > (int)Data::classes.size())
+        if (id < 1 || id > static_cast<int>(Data::classes.size()))
             return QString("<%1?>").arg(id);
-        return QString::fromStdString(Data::classes[id-1].name);
+        return QString::fromStdString(Data::classes[static_cast<size_t>(id)-1].name);
     }
 
     QString stateName(int id)
     {
-        if (id < 1 || id > (int)Data::states.size())
+        if (id < 1 || id > static_cast<int>(Data::states.size()))
             return QString("<%1?>").arg(id);
-        return QString::fromStdString(Data::states[id-1].name);
+        return QString::fromStdString(Data::states[static_cast<size_t>(id)-1].name);
     }
 
     QString skillName(int id)
     {
-        if (id < 1 || id > (int)Data::skills.size())
+        if (id < 1 || id > static_cast<int>(Data::skills.size()))
             return QString("<%1?>").arg(id);
-        return QString::fromStdString(Data::skills[id-1].name);
+        return QString::fromStdString(Data::skills[static_cast<size_t>(id)-1].name);
     }
 
     QString battleCommandName(int id)
     {
-        if (id < 1 || id > (int)Data::battlecommands.commands.size())
+        if (id < 1 || id > static_cast<int>(Data::battlecommands.commands.size()))
             return QString("<%1?>").arg(id);
-        return QString::fromStdString(Data::battlecommands.commands[id-1].name);
+        return QString::fromStdString(Data::battlecommands.commands[static_cast<size_t>(id)-1].name);
     }
 
 
     QString animationName(int id)
     {
-        if (id < 1 || id > (int)Data::animations.size())
+        if (id < 1 || id > static_cast<int>(Data::animations.size()))
             return QString("<%1?>").arg(id);
-        return QString::fromStdString(Data::animations[id-1].name);
+        return QString::fromStdString(Data::animations[static_cast<size_t>(id)-1].name);
     }
     QString conditionName(int id)
     {
-        if (id < 1 || id > (int)Data::states.size())
+        if (id < 1 || id > static_cast<int>(Data::states.size()))
             return QString("<%1?>").arg(id);
-        return QString::fromStdString(Data::states[id-1].name);
+        return QString::fromStdString(Data::states[static_cast<size_t>(id)-1].name);
     }
 
     QString eventName(int id)
@@ -1270,28 +1272,28 @@ namespace Stringizer
 
     QString commonEventName(int id)
     {
-        if (id < 1 || id > (int)Data::commonevents.size())
+        if (id < 1 || id > static_cast<int>(Data::commonevents.size()))
             return QString("<%1?>").arg(id);
-        return QString::fromStdString(Data::commonevents[id-1].name);
+        return QString::fromStdString(Data::commonevents[static_cast<size_t>(id)-1].name);
     }
 
     QString troopName(int id)
     {
-        if (id < 1 || id > (int)Data::troops.size())
+        if (id < 1 || id > static_cast<int>(Data::troops.size()))
             return QString("<%1?>").arg(id);
-        return QString::fromStdString(Data::troops[id-1].name);
+        return QString::fromStdString(Data::troops[static_cast<size_t>(id)-1].name);
     }
 
     QString terrainName(int id)
     {
-        if (id < 1 || id > (int)Data::terrains.size())
+        if (id < 1 || id > static_cast<int>(Data::terrains.size()))
             return QString("<%1?>").arg(id);
-        return QString::fromStdString(Data::terrains[id-1].name);
+        return QString::fromStdString(Data::terrains[static_cast<size_t>(id)-1].name);
     }
 
     QString mapName(int id)
     {
-        if (id < 1 || id > (int)Data::treemap.maps.size())
+        if (id < 1 || id > static_cast<int>(Data::treemap.maps.size()))
             return QString("<%1?>").arg(id);
         for (unsigned i = 0; i < Data::treemap.maps.size(); i++)
             if (Data::treemap.maps[i].ID == id)
@@ -1391,10 +1393,10 @@ namespace Stringizer
             };
         if (id < 0)
             return tr("Use Default");
-        else if (id >= (int)erase_transitions.size())
+        else if (id >= static_cast<int>(erase_transitions.size()))
             return tr("Unknown");
         else
-            return erase_transitions[id];
+            return erase_transitions[static_cast<size_t>(id)];
     }
 
     QString showTransitionName(int id)
@@ -1423,10 +1425,10 @@ namespace Stringizer
             };
         if (id < 0)
             return tr("Use Default");
-        else if (id >= (int)show_transitions.size())
+        else if (id >= static_cast<int>(show_transitions.size()))
             return tr("Unknown");
         else
-            return show_transitions[id];
+            return show_transitions[static_cast<size_t>(id)];
     }
 
     QString stringize(const RPG::EventCommand& com)

--- a/src/tools/qactordelegate.cpp
+++ b/src/tools/qactordelegate.cpp
@@ -12,7 +12,7 @@ QWidget *QActorDelegate::createEditor(QWidget *parent, const QStyleOptionViewIte
     Q_UNUSED(option)
     QComboBox *editor = new QComboBox(parent);
     editor->addItem(tr("<None>"), 0);
-    for (int i = 0; i < (int)Data::actors.size(); i++)
+    for (size_t i = 0; i < Data::actors.size(); i++)
         editor->addItem(QString::fromStdString(Data::actors[i].name), Data::actors[i].ID);
     return editor;
 }
@@ -27,7 +27,7 @@ void QActorDelegate::setModelData(QWidget *editor, QAbstractItemModel *model, co
 {
     int id = static_cast<QComboBox*>(editor)->currentIndex() + 1;
     model->setData(index, id, Qt::UserRole);
-    model->setData(index, QString::fromStdString(Data::actors[id-1].name));
+    model->setData(index, QString::fromStdString(Data::actors[static_cast<size_t>(id)-1].name));
 }
 
 void QActorDelegate::updateEditorGeometry(QWidget *editor, const QStyleOptionViewItem &option, const QModelIndex &index) const

--- a/src/tools/qactordelegate.h
+++ b/src/tools/qactordelegate.h
@@ -8,7 +8,7 @@ class QActorDelegate : public QItemDelegate
 {
     Q_OBJECT
 public:
-    explicit QActorDelegate(QObject *parent = 0);
+    explicit QActorDelegate(QObject *parent = nullptr);
 
     QWidget *createEditor(QWidget *parent,
                           const QStyleOptionViewItem &option,

--- a/src/tools/qdbpageactors.cpp
+++ b/src/tools/qdbpageactors.cpp
@@ -12,7 +12,7 @@ QDbPageActors::QDbPageActors(RPG::Database &database, QWidget *parent) :
     const auto kMaxHp = database.system.ldb_id == 2003 ? 9999 : 999;
     ui->setupUi(this);
 
-    m_currentActor = 0;
+    m_currentActor = nullptr;
 
     ui->spinMaxLv->setMaximum(kMaxLevel);
 
@@ -170,10 +170,10 @@ void QDbPageActors::on_comboBattleset_currentIndexChanged(int index)
 
     m_currentActor->battler_animation = index;
 
-    if (index <= 0 || index >= (int)m_data.battleranimations.size())
+    if (index <= 0 || index >= static_cast<int>(m_data.battleranimations.size()))
         m_battlerItem->setBasePix(QGraphicsBattleAnimationItem::Battler,"");
     else
-        m_battlerItem->setDemoAnimation(m_data.battleranimations[index-1]);
+        m_battlerItem->setDemoAnimation(m_data.battleranimations[static_cast<size_t>(index) - 1]);
 }
 
 void QDbPageActors::on_checkDualWeapon_toggled(bool checked)
@@ -219,7 +219,7 @@ void QDbPageActors::on_comboInitialWeapon_currentIndexChanged(int index)
     if(!m_currentActor) return;
     if(m_currentActor->initial_equipment.weapon_id == ui->comboInitialWeapon->itemData(index))
         return;
-    m_currentActor->initial_equipment.weapon_id = ui->comboInitialWeapon->itemData(index).toInt();
+    m_currentActor->initial_equipment.weapon_id = static_cast<short>(ui->comboInitialWeapon->itemData(index).toInt());
 }
 
 void QDbPageActors::on_comboInitialShield_currentIndexChanged(int index)
@@ -228,7 +228,7 @@ void QDbPageActors::on_comboInitialShield_currentIndexChanged(int index)
     if(!m_currentActor) return;
     if(m_currentActor->initial_equipment.shield_id == ui->comboInitialShield->itemData(index).toInt())
         return;
-    m_currentActor->initial_equipment.shield_id = ui->comboInitialShield->itemData(index).toInt();
+    m_currentActor->initial_equipment.shield_id = static_cast<short>(ui->comboInitialShield->itemData(index).toInt());
 }
 void QDbPageActors::on_comboInitialArmor_currentIndexChanged(int index)
 {
@@ -236,7 +236,7 @@ void QDbPageActors::on_comboInitialArmor_currentIndexChanged(int index)
     if(!m_currentActor) return;
     if(m_currentActor->initial_equipment.armor_id == ui->comboInitialArmor->itemData(index).toInt())
         return;
-    m_currentActor->initial_equipment.armor_id = ui->comboInitialArmor->itemData(index).toInt();
+    m_currentActor->initial_equipment.armor_id = static_cast<short>(ui->comboInitialArmor->itemData(index).toInt());
 }
 void QDbPageActors::on_comboInitialHelmet_currentIndexChanged(int index)
 {
@@ -244,7 +244,7 @@ void QDbPageActors::on_comboInitialHelmet_currentIndexChanged(int index)
     if(!m_currentActor) return;
     if(m_currentActor->initial_equipment.helmet_id == ui->comboInitialHelmet->itemData(index).toInt())
         return;
-    m_currentActor->initial_equipment.helmet_id = ui->comboInitialHelmet->itemData(index).toInt();
+    m_currentActor->initial_equipment.helmet_id = static_cast<short>(ui->comboInitialHelmet->itemData(index).toInt());
 }
 void QDbPageActors::on_comboInitialMisc_currentIndexChanged(int index)
 {
@@ -252,7 +252,7 @@ void QDbPageActors::on_comboInitialMisc_currentIndexChanged(int index)
     if(!m_currentActor) return;
     if(m_currentActor->initial_equipment.accessory_id == ui->comboInitialMisc->itemData(index).toInt())
         return;
-    m_currentActor->initial_equipment.accessory_id = ui->comboInitialMisc->itemData(index).toInt();
+    m_currentActor->initial_equipment.accessory_id = static_cast<short>(ui->comboInitialMisc->itemData(index).toInt());
 }
 
 void QDbPageActors::on_comboUnarmedAnimation_currentIndexChanged(int index)
@@ -318,11 +318,11 @@ void QDbPageActors::ResetExpText(RPG::Actor* actor) {
 
 void QDbPageActors::on_currentActorChanged(RPG::Actor *actor)
 {
-    m_currentActor = 0;
+    m_currentActor = nullptr;
 
     ResetExpText(actor);
 
-    if (actor == 0){
+    if (actor == nullptr){
         /* Clear widgets */
         ui->lineName->clear();
         ui->lineTitle->clear();
@@ -403,14 +403,14 @@ void QDbPageActors::on_currentActorChanged(RPG::Actor *actor)
     ui->comboInitialMisc->addItem(tr("<none>"), 0);
     ui->comboInitialShield->addItem(tr("<none>"), 0);
     ui->comboInitialWeapon->addItem(tr("<none>"), 0);
-    for (unsigned int i = 0; i < m_data.items.size(); i++)
+    for (size_t i = 0; i < m_data.items.size(); i++)
     {
         /* Check if hero can use item*/
-        if (actor->ID <= (int) m_data.items[i].actor_set.size() &&
-                !m_data.items[i].actor_set[actor->ID-1])
+        if (actor->ID <= static_cast<int>(m_data.items[i].actor_set.size()) &&
+                !m_data.items[i].actor_set[static_cast<size_t>(actor->ID)-1])
             if (actor->class_id <= 0 ||
-                    (actor->class_id >= (int) m_data.items[i].class_set.size() &&
-                     ((m_data.items[i].class_set.size()>0) &&(!m_data.items[i].class_set[actor->class_id-1]))))
+                    (actor->class_id >= static_cast<int>(m_data.items[i].class_set.size()) &&
+                     ((m_data.items[i].class_set.size()>0) &&(!m_data.items[i].class_set[static_cast<size_t>(actor->class_id)-1]))))
                 continue;
 
         switch (m_data.items[i].type)
@@ -445,32 +445,32 @@ void QDbPageActors::on_currentActorChanged(RPG::Actor *actor)
     ui->comboProfession->setCurrentIndex(actor->class_id);
     ui->comboUnarmedAnimation->setCurrentIndex(actor->unarmed_animation);
     ui->tableSkills->setRowCount(0);
-    for (unsigned int i = 0; i < actor->skills.size(); i++){
+    for (int i = 0; i < static_cast<int>(actor->skills.size()); i++){
         ui->tableSkills->insertRow(i);
         ui->tableSkills->setItem(i,0,new QTableWidgetItem());
         ui->tableSkills->setItem(i,1,new QTableWidgetItem());
-        ui->tableSkills->item(i, 0)->setText(QString::number(actor->skills[i].level));
+        ui->tableSkills->item(i, 0)->setText(QString::number(actor->skills[static_cast<size_t>(i)].level));
         // TODO: move getSkillName to Core
-        QString name = QString("<%1?>").arg(actor->skills[i].skill_id);
-        if ((unsigned) actor->skills[i].skill_id < m_data.skills.size())
-            name = m_data.skills[actor->skills[i].skill_id-1].name.c_str();
+        QString name = QString("<%1?>").arg(actor->skills[static_cast<size_t>(i)].skill_id);
+        if (actor->skills[static_cast<size_t>(i)].skill_id < static_cast<int>(m_data.skills.size()))
+            name = m_data.skills[static_cast<size_t>(actor->skills[static_cast<size_t>(i)].skill_id)-1].name.c_str();
         // TODO/
         ui->tableSkills->item(i, 1)->setText(name);
     }
-    ui->tableSkills->insertRow((int)actor->skills.size());
+    ui->tableSkills->insertRow(static_cast<int>(actor->skills.size()));
     for (int i = 0; i < ui->listAttributeRanks->count(); i++)
     {
-        if (i >= (int)actor->attribute_ranks.size())
-            ui->listAttributeRanks->item(i)->setIcon(QIcon(":/embedded/share/old_rank2.png"));
+        if (i >= static_cast<int>(actor->attribute_ranks.size()))
+            ui->listAttributeRanks->item(static_cast<int>(i))->setIcon(QIcon(":/embedded/share/old_rank2.png"));
         else
-            ui->listAttributeRanks->item(i)->setIcon(QIcon(QString(":/embedded/share/old_rank%1.png").arg((int)actor->attribute_ranks[i])));
+            ui->listAttributeRanks->item(static_cast<int>(i))->setIcon(QIcon(QString(":/embedded/share/old_rank%1.png").arg(static_cast<int>(actor->attribute_ranks[static_cast<size_t>(i)]))));
     }
     for (int i = 0; i < ui->listStatusRanks->count(); i++)
     {
-        if (i >= (int)actor->state_ranks.size())
+        if (i >= static_cast<int>(actor->state_ranks.size()))
             ui->listStatusRanks->item(i)->setIcon(QIcon(":/embedded/share/old_rank2.png"));
         else
-            ui->listStatusRanks->item(i)->setIcon(QIcon(QString(":/embedded/share/old_rank%1.png").arg((int)actor->state_ranks[i])));
+            ui->listStatusRanks->item(i)->setIcon(QIcon(QString(":/embedded/share/old_rank%1.png").arg(static_cast<int>(actor->state_ranks[static_cast<size_t>(i)]))));
     }
     m_charaItem->setVisible(true);
     m_charaItem->setBasePix(actor->character_name.c_str());
@@ -482,10 +482,10 @@ void QDbPageActors::on_currentActorChanged(RPG::Actor *actor)
     m_faceItem->setIndex(actor->face_index);
 
     if (actor->battler_animation <= 0 ||
-            actor->battler_animation >= (int)m_data.battleranimations.size())
+            actor->battler_animation >= static_cast<int>(m_data.battleranimations.size()))
         m_battlerItem->setBasePix(QGraphicsBattleAnimationItem::Battler,"");
     else
-        m_battlerItem->setDemoAnimation(m_data.battleranimations[actor->battler_animation-1]);
+        m_battlerItem->setDemoAnimation(m_data.battleranimations[static_cast<size_t>(actor->battler_animation)-1]);
 
     m_hpItem->setData(actor->parameters.maxhp);
     m_mpItem->setData(actor->parameters.maxsp);
@@ -527,15 +527,15 @@ void QDbPageActors::on_currentActorChanged(RPG::Actor *actor)
 
 void QDbPageActors::on_listCharacters_currentRowChanged(int currentRow)
 {
-    if (currentRow < 0 || currentRow >= (int)m_data.actors.size())
+    if (currentRow < 0 || currentRow >= static_cast<int>(m_data.actors.size()))
     {
-        on_currentActorChanged(0);
-        emit currentActorChanged(0);
+        on_currentActorChanged(nullptr);
+        emit currentActorChanged(nullptr);
         return; //invalid
     }
 
-    on_currentActorChanged(&m_data.actors[currentRow]);
-    emit currentActorChanged(&m_data.actors[currentRow]);
+    on_currentActorChanged(&m_data.actors[static_cast<size_t>(currentRow)]);
+    emit currentActorChanged(&m_data.actors[static_cast<size_t>(currentRow)]);
 }
 
 void QDbPageActors::on_checkTranslucent_toggled(bool checked)
@@ -552,10 +552,10 @@ void QDbPageActors::on_pushApplyProfession_clicked()
     if (!m_currentActor)
         return;
 
-    const RPG::Class &n_class = m_data.classes[ui->comboProfession->currentIndex()];
+    const RPG::Class &n_class = m_data.classes[static_cast<size_t>(ui->comboProfession->currentIndex())];
     /* Disconnect widgets */
     RPG::Actor *actor = m_currentActor;
-    m_currentActor = 0;
+    m_currentActor = nullptr;
     /* /Disconnect widgets */
     actor->class_id = ui->comboProfession->currentIndex();
     actor->attribute_ranks = n_class.attribute_ranks;

--- a/src/tools/qdbpageactors.h
+++ b/src/tools/qdbpageactors.h
@@ -21,7 +21,7 @@ class QDbPageActors : public QWidget
     Q_OBJECT
 
 public:
-    explicit QDbPageActors(RPG::Database &database, QWidget *parent = 0);
+    explicit QDbPageActors(RPG::Database &database, QWidget *parent = nullptr);
     ~QDbPageActors();
 
 public slots:

--- a/src/tools/qdbpageattributes.h
+++ b/src/tools/qdbpageattributes.h
@@ -13,7 +13,7 @@ class QDbPageAttributes : public QWidget
     Q_OBJECT
 
 public:
-    explicit QDbPageAttributes(RPG::Database &database, QWidget *parent = 0);
+    explicit QDbPageAttributes(RPG::Database &database, QWidget *parent = nullptr);
     ~QDbPageAttributes();
 
 private:

--- a/src/tools/qdbpagebattleanimations.h
+++ b/src/tools/qdbpagebattleanimations.h
@@ -13,7 +13,7 @@ class QDbPageBattleAnimations : public QWidget
     Q_OBJECT
 
 public:
-    explicit QDbPageBattleAnimations(RPG::Database &database, QWidget *parent = 0);
+    explicit QDbPageBattleAnimations(RPG::Database &database, QWidget *parent = nullptr);
     ~QDbPageBattleAnimations();
 
 private:

--- a/src/tools/qdbpagebattleanimations2.h
+++ b/src/tools/qdbpagebattleanimations2.h
@@ -13,7 +13,7 @@ class QDbPageBattleAnimations2 : public QWidget
     Q_OBJECT
 
 public:
-    explicit QDbPageBattleAnimations2(RPG::Database &database, QWidget *parent = 0);
+    explicit QDbPageBattleAnimations2(RPG::Database &database, QWidget *parent = nullptr);
     ~QDbPageBattleAnimations2();
 
 private:

--- a/src/tools/qdbpagebattlescreen.h
+++ b/src/tools/qdbpagebattlescreen.h
@@ -13,7 +13,7 @@ class QDbPageBattleScreen : public QWidget
     Q_OBJECT
 
 public:
-    explicit QDbPageBattleScreen(RPG::Database &database, QWidget *parent = 0);
+    explicit QDbPageBattleScreen(RPG::Database &database, QWidget *parent = nullptr);
     ~QDbPageBattleScreen();
 
 private:

--- a/src/tools/qdbpagechipset.h
+++ b/src/tools/qdbpagechipset.h
@@ -13,7 +13,7 @@ class QDbPageChipset : public QWidget
     Q_OBJECT
 
 public:
-    explicit QDbPageChipset(RPG::Database &database, QWidget *parent = 0);
+    explicit QDbPageChipset(RPG::Database &database, QWidget *parent = nullptr);
     ~QDbPageChipset();
 
 private:

--- a/src/tools/qdbpageclasses.cpp
+++ b/src/tools/qdbpageclasses.cpp
@@ -9,7 +9,7 @@ QDbPageClasses::QDbPageClasses(RPG::Database &database, QWidget *parent) :
 {
     ui->setupUi(this);
 
-    m_currentClass = 0;
+    m_currentClass = nullptr;
 
     m_battlerItem = new QGraphicsBattleAnimationItem();
 

--- a/src/tools/qdbpageclasses.h
+++ b/src/tools/qdbpageclasses.h
@@ -15,7 +15,7 @@ class QDbPageClasses : public QWidget
     Q_OBJECT
 
 public:
-    explicit QDbPageClasses(RPG::Database &database, QWidget *parent = 0);
+    explicit QDbPageClasses(RPG::Database &database, QWidget *parent = nullptr);
     ~QDbPageClasses();
 
     void UpdateModels();

--- a/src/tools/qdbpagecommonevents.h
+++ b/src/tools/qdbpagecommonevents.h
@@ -13,7 +13,7 @@ class QDbPageCommonEvents : public QWidget
     Q_OBJECT
 
 public:
-    explicit QDbPageCommonEvents(RPG::Database &database, QWidget *parent = 0);
+    explicit QDbPageCommonEvents(RPG::Database &database, QWidget *parent = nullptr);
     ~QDbPageCommonEvents();
 
 private:

--- a/src/tools/qdbpageenemies.h
+++ b/src/tools/qdbpageenemies.h
@@ -13,7 +13,7 @@ class QDbPageEnemies : public QWidget
     Q_OBJECT
 
 public:
-    explicit QDbPageEnemies(RPG::Database &database, QWidget *parent = 0);
+    explicit QDbPageEnemies(RPG::Database &database, QWidget *parent = nullptr);
     ~QDbPageEnemies();
 
 private:

--- a/src/tools/qdbpageenemygroups.h
+++ b/src/tools/qdbpageenemygroups.h
@@ -13,7 +13,7 @@ class QDbPageEnemyGroups : public QWidget
     Q_OBJECT
 
 public:
-    explicit QDbPageEnemyGroups(RPG::Database &database, QWidget *parent = 0);
+    explicit QDbPageEnemyGroups(RPG::Database &database, QWidget *parent = nullptr);
     ~QDbPageEnemyGroups();
 
 private:

--- a/src/tools/qdbpageherostatus.h
+++ b/src/tools/qdbpageherostatus.h
@@ -13,7 +13,7 @@ class QDbPageHeroStatus : public QWidget
     Q_OBJECT
 
 public:
-    explicit QDbPageHeroStatus(RPG::Database &database, QWidget *parent = 0);
+    explicit QDbPageHeroStatus(RPG::Database &database, QWidget *parent = nullptr);
     ~QDbPageHeroStatus();
 
 private:

--- a/src/tools/qdbpageitems.h
+++ b/src/tools/qdbpageitems.h
@@ -13,7 +13,7 @@ class QDbPageItems : public QWidget
     Q_OBJECT
 
 public:
-    explicit QDbPageItems(RPG::Database &database, QWidget *parent = 0);
+    explicit QDbPageItems(RPG::Database &database, QWidget *parent = nullptr);
     ~QDbPageItems();
 
 private:

--- a/src/tools/qdbpageskills.h
+++ b/src/tools/qdbpageskills.h
@@ -13,7 +13,7 @@ class QDbPageSkills : public QWidget
     Q_OBJECT
 
 public:
-    explicit QDbPageSkills(RPG::Database &database, QWidget *parent = 0);
+    explicit QDbPageSkills(RPG::Database &database, QWidget *parent = nullptr);
     ~QDbPageSkills();
 
 private:

--- a/src/tools/qdbpagesystem.h
+++ b/src/tools/qdbpagesystem.h
@@ -13,7 +13,7 @@ class QDbPageSystem : public QWidget
     Q_OBJECT
 
 public:
-    explicit QDbPageSystem(RPG::Database &database, QWidget *parent = 0);
+    explicit QDbPageSystem(RPG::Database &database, QWidget *parent = nullptr);
     ~QDbPageSystem();
 
 private:

--- a/src/tools/qdbpagesystem2.h
+++ b/src/tools/qdbpagesystem2.h
@@ -13,7 +13,7 @@ class QDbPageSystem2 : public QWidget
     Q_OBJECT
 
 public:
-    explicit QDbPageSystem2(RPG::Database &database, QWidget *parent = 0);
+    explicit QDbPageSystem2(RPG::Database &database, QWidget *parent = nullptr);
     ~QDbPageSystem2();
 
 private:

--- a/src/tools/qdbpageterrain.h
+++ b/src/tools/qdbpageterrain.h
@@ -13,7 +13,7 @@ class QDbPageTerrain : public QWidget
     Q_OBJECT
 
 public:
-    explicit QDbPageTerrain(RPG::Database &database, QWidget *parent = 0);
+    explicit QDbPageTerrain(RPG::Database &database, QWidget *parent = nullptr);
     ~QDbPageTerrain();
 
 private:

--- a/src/tools/qdbpagevocabulary.h
+++ b/src/tools/qdbpagevocabulary.h
@@ -14,7 +14,7 @@ class QDbPageVocabulary : public QWidget
 
     RPG::Terms *terms;
 public:
-    explicit QDbPageVocabulary(RPG::Database &database, QWidget *parent = 0);
+    explicit QDbPageVocabulary(RPG::Database &database, QWidget *parent = nullptr);
     ~QDbPageVocabulary();
 private slots:
     void on_lineEdit_34_textChanged(const QString &arg1);

--- a/src/tools/qencounterdelegate.cpp
+++ b/src/tools/qencounterdelegate.cpp
@@ -12,7 +12,7 @@ QWidget *QEncounterDelegate::createEditor(QWidget *parent, const QStyleOptionVie
     Q_UNUSED(index)
     Q_UNUSED(option)
     QComboBox *editor = new QComboBox(parent);
-    for (int i = 0; i < (int)Data::troops.size(); i++)
+    for (size_t i = 0; i < Data::troops.size(); i++)
         editor->addItem(QString::fromStdString(Data::troops[i].name));
     return editor;
 }
@@ -27,7 +27,7 @@ void QEncounterDelegate::setModelData(QWidget *editor, QAbstractItemModel *model
 {
     int id = static_cast<QComboBox*>(editor)->currentIndex() + 1;
     model->setData(index, id, Qt::UserRole);
-    model->setData(index, QString::fromStdString(Data::troops[id-1].name));
+    model->setData(index, QString::fromStdString(Data::troops[static_cast<size_t>(id)-1].name));
 }
 
 void QEncounterDelegate::updateEditorGeometry(QWidget *editor, const QStyleOptionViewItem &option, const QModelIndex &index) const

--- a/src/tools/qencounterdelegate.h
+++ b/src/tools/qencounterdelegate.h
@@ -9,7 +9,7 @@ class QEncounterDelegate : public QItemDelegate
 {
     Q_OBJECT
 public:
-    explicit QEncounterDelegate(QObject *parent = 0);
+    explicit QEncounterDelegate(QObject *parent = nullptr);
 
     QWidget *createEditor(QWidget *parent,
                           const QStyleOptionViewItem &option,

--- a/src/tools/qeventpagewidget.cpp
+++ b/src/tools/qeventpagewidget.cpp
@@ -11,7 +11,7 @@
 QEventPageWidget::QEventPageWidget(QWidget *parent) :
     QWidget(parent),
     ui(new Ui::QEventWidget),
-    m_eventPage(0)
+    m_eventPage(nullptr)
 {
     ui->setupUi(this);
     for (unsigned int i = 0; i < Data::items.size(); i++)
@@ -80,7 +80,7 @@ void QEventPageWidget::setEventPage(RPG::EventPage *eventPage)
     updateGraphic();
 
     m_codeGen = 0;
-    QTreeWidgetItem *parent = 0;
+    QTreeWidgetItem *parent = nullptr;
     for (unsigned int i = 0; i < m_eventPage->event_commands.size(); i++)
     {
         const RPG::EventCommand& command = m_eventPage->event_commands[i];
@@ -146,10 +146,10 @@ void QEventPageWidget::on_comboMoveType_currentIndexChanged(int index)
  * @return Formatted text
  */
 QString formatSwitchCondition(int switchId) {
-    if (switchId >= 1 && switchId <= Data::switches.size()) {
+    if (switchId >= 1 && switchId <= static_cast<int>(Data::switches.size())) {
         return QString("%1: %2").arg(switchId)
                 .arg(QString::fromStdString
-                     (Data::switches[switchId-1].name));
+                     (Data::switches[static_cast<size_t>(switchId) - 1].name));
     }
     else {
         return QString("%1: ???").arg(switchId);
@@ -190,10 +190,10 @@ void QEventPageWidget::on_checkVar_toggled(bool checked)
         return;
     if (checked) {
         int varId = m_eventPage->condition.variable_id;
-        if (varId >= 1 && varId <= Data::variables.size()) {
+        if (varId >= 1 && varId <= static_cast<int>(Data::variables.size())) {
             ui->lineVar->setText(QString("%1: %2").arg(varId)
                 .arg(QString::fromStdString
-                     (Data::variables[varId - 1].name)));
+                     (Data::variables[static_cast<size_t>(varId) - 1].name)));
         }
         else {
             ui->lineVar->setText(QString("%1: ???").arg(varId));
@@ -366,7 +366,7 @@ void QEventPageWidget::updateGraphic()
         QPixmap pix(16,16);
         pix.fill(QColor(0,0,0,0));
         mCore->beginPainting(pix);
-        mCore->renderTile(10000+m_eventPage->character_index,QRect(0,0,16,16));
+        mCore->renderTile(10000 + static_cast<short>(m_eventPage->character_index), QRect(0,0,16,16));
         mCore->endPainting();
         m_tileItem->setPixmap(pix);
         m_tileItem->setVisible(true);

--- a/src/tools/qeventpagewidget.h
+++ b/src/tools/qeventpagewidget.h
@@ -22,7 +22,7 @@ class QEventPageWidget : public QWidget
     Q_OBJECT
 
 public:
-    explicit QEventPageWidget(QWidget *parent = 0);
+    explicit QEventPageWidget(QWidget *parent = nullptr);
     ~QEventPageWidget();
 
     RPG::EventPage *eventPage() const;

--- a/src/tools/qgraphicsbattleanimationitem.cpp
+++ b/src/tools/qgraphicsbattleanimationitem.cpp
@@ -85,7 +85,7 @@ void QGraphicsBattleAnimationItem::on_demoAdvance()
     m_demoIndex++;
     if (m_demoIndex > 11)
         m_demoIndex = 0;
-    RPG::BattlerAnimationExtension anim = m_demoAnimation.base_data[m_demoIndex];
+    RPG::BattlerAnimationExtension anim = m_demoAnimation.base_data[static_cast<size_t>(m_demoIndex)];
     setBasePix(Battler, QString::fromStdString(anim.battler_name));
     m_index = anim.battler_index;
     updatePix();

--- a/src/tools/qgraphicscurveitem.cpp
+++ b/src/tools/qgraphicscurveitem.cpp
@@ -28,9 +28,9 @@ void QGraphicsCurveItem::paint(QPainter *painter, const QStyleOptionGraphicsItem
     QRectF r = scene()->sceneRect();
     QVector<QPointF> p;
     p.append(r.bottomLeft());
-    for (int i = 0; i < (int)m_data.size(); i++)
-        p.append(QPointF(((qreal)i*r.width())/99.0,
-                         r.height()-r.height()*(qreal)m_data[i]/m_maxValue));
+    for (size_t i = 0; i < m_data.size(); i++)
+        p.append(QPointF((static_cast<qreal>(i)*r.width())/99.0,
+                         r.height()-r.height()*static_cast<qreal>(m_data[i])/m_maxValue));
     p.append(r.bottomRight());
 
     painter->fillRect(r, Qt::black);

--- a/src/tools/qgraphicscurveitem.h
+++ b/src/tools/qgraphicscurveitem.h
@@ -8,7 +8,7 @@
 class QGraphicsCurveItem : public QGraphicsItem
 {
 public:
-    explicit QGraphicsCurveItem(QColor color, std::vector<int16_t> &data, QGraphicsItem *parent = 0);
+    explicit QGraphicsCurveItem(QColor color, std::vector<int16_t> &data, QGraphicsItem *parent = nullptr);
 
     QRectF boundingRect() const;
 

--- a/src/tools/qgraphicsmapscene.cpp
+++ b/src/tools/qgraphicsmapscene.cpp
@@ -137,8 +137,8 @@ void QGraphicsMapScene::Init()
             SIGNAL(layerChanged()),
             this,
             SLOT(onLayerChanged()));
-    m_view->verticalScrollBar()->setValue(n_mapInfo.scrollbar_y*m_scale);
-    m_view->horizontalScrollBar()->setValue(n_mapInfo.scrollbar_x*m_scale);
+    m_view->verticalScrollBar()->setValue(n_mapInfo.scrollbar_y *static_cast<int>(m_scale));
+    m_view->horizontalScrollBar()->setValue(n_mapInfo.scrollbar_x * static_cast<int>(m_scale));
     m_init = true;
     redrawMap();
 }
@@ -210,7 +210,7 @@ void QGraphicsMapScene::redrawMap()
         return;
     mCore->LoadChipset(m_map->chipset_id);
     mCore->setCurrentMapEvents(mapEvents());
-    s_tileSize = mCore->tileSize()*m_scale;
+    s_tileSize =mCore->tileSize() *static_cast<int>(m_scale);
     redrawLayer(Core::LOWER);
     redrawLayer(Core::UPPER);
 }
@@ -218,12 +218,12 @@ void QGraphicsMapScene::redrawMap()
 void QGraphicsMapScene::setScale(float scale)
 {
     m_scale = scale;
-    m_lines->setScale(m_scale);
-    m_selectionTile->setScale(m_scale);
+    m_lines->setScale(static_cast<int>(m_scale));
+    m_selectionTile->setScale(static_cast<int>(m_scale));
     this->setSceneRect(0,
                        0,
-                       m_map->width* mCore->tileSize()*m_scale,
-                       m_map->height* mCore->tileSize()*m_scale);
+                       m_map->width * mCore->tileSize() * static_cast<int>(m_scale),
+                       m_map->height * mCore->tileSize() * static_cast<int>(m_scale));
     redrawMap();
 }
 
@@ -250,8 +250,8 @@ void QGraphicsMapScene::onLayerChanged()
         m_upperpix->graphicsEffect()->setEnabled(false);
         m_lines->setVisible(true);
         break;
-    default:
-        Q_ASSERT(false);
+//    default:
+//        Q_ASSERT(false);
     }
 }
 
@@ -418,7 +418,7 @@ void QGraphicsMapScene::on_view_V_Scroll()
         return;
     if (m_view->verticalScrollBar()->isVisible())
     {
-        n_mapInfo.scrollbar_y = m_view->verticalScrollBar()->value()/m_scale;
+        n_mapInfo.scrollbar_y = m_view->verticalScrollBar()->value() / static_cast<int>(m_scale);
     }
     m_userInteraction = false;
     LMT_Reader::SaveXml(mCore->filePath(ROOT,EASY_MT).toStdString());
@@ -430,7 +430,7 @@ void QGraphicsMapScene::on_view_H_Scroll()
         return;
     if (m_view->horizontalScrollBar()->isVisible())
     {
-        n_mapInfo.scrollbar_x = m_view->horizontalScrollBar()->value()/m_scale;
+        n_mapInfo.scrollbar_x = m_view->horizontalScrollBar()->value() / static_cast<int>(m_scale);
     }
     m_userInteraction = false;
     LMT_Reader::SaveXml(mCore->filePath(ROOT,EASY_MT).toStdString());
@@ -451,12 +451,12 @@ void QGraphicsMapScene::mousePressEvent(QGraphicsSceneMouseEvent *event)
             lst_y = cur_y;
             m_eventMenu->popup(event->screenPos());
         }
-        if (mCore->tool() == Core::ZOOM && m_scale > 0.25)
+        if (mCore->tool() == Core::ZOOM && static_cast<double>(m_scale) > 0.25)
             setScale(m_scale/2);
     }
     if (event->button() == Qt::LeftButton)
     {
-        if (mCore->tool() == Core::ZOOM && m_scale < 2.0) // Zoom
+        if (mCore->tool() == Core::ZOOM && static_cast<double>(m_scale) < 2.0) // Zoom
             setScale(m_scale*2);
         else if (mCore->layer() == Core::EVENT) // Select tile
         {
@@ -482,10 +482,11 @@ void QGraphicsMapScene::mousePressEvent(QGraphicsSceneMouseEvent *event)
             case Core::FILL:
                 m_drawing = true;
                 if (mCore->layer() == Core::LOWER)
-                    drawFill(mCore->translate(m_lower[_index(fst_x,fst_y)]),fst_x,fst_y);
+                    drawFill(mCore->translate(m_lower[static_cast<size_t>(_index(fst_x,fst_y))]),fst_x,fst_y);
                 else if (mCore->layer() == Core::UPPER)
-                    drawFill(mCore->translate(m_upper[_index(fst_x,fst_y)]),fst_x,fst_y);
+                    drawFill(mCore->translate(m_upper[static_cast<size_t>(_index(fst_x,fst_y))]),fst_x,fst_y);
                 updateArea(0, 0, m_map->width-1 ,m_map->height-1);
+                break;
             default:
                 break;
             }
@@ -497,10 +498,10 @@ void QGraphicsMapScene::mouseMoveEvent(QGraphicsSceneMouseEvent *event)
 {
     if (!sceneRect().contains(event->scenePos()))
         return;
-    if (cur_x == event->scenePos().x()/s_tileSize && cur_y == event->scenePos().y()/s_tileSize)
+    if (cur_x == static_cast<int>(event->scenePos().x() / s_tileSize) && cur_y == static_cast<int>(event->scenePos().y() / s_tileSize))
         return;
-    cur_x = event->scenePos().x()/s_tileSize;
-    cur_y = event->scenePos().y()/s_tileSize;
+    cur_x = static_cast<int>(event->scenePos().x() / s_tileSize);
+    cur_y = static_cast<int>(event->scenePos().y() / s_tileSize);
     if (m_drawing)
     {
         switch (mCore->tool())
@@ -612,10 +613,10 @@ void QGraphicsMapScene::redrawTile(const Core::Layer &layer,
     switch (layer)
     {
     case (Core::LOWER):
-        mCore->renderTile(m_lower[_index(x,y)],dest_rec);
+        mCore->renderTile(m_lower[static_cast<size_t>(_index(x,y))],dest_rec);
         break;
     case (Core::UPPER):
-        mCore->renderTile(m_upper[_index(x,y)],dest_rec);
+        mCore->renderTile(m_upper[static_cast<size_t>(_index(x,y))],dest_rec);
         break;
     default:
         break;
@@ -659,9 +660,9 @@ void QGraphicsMapScene::updateArea(int x1, int y1, int x2, int y2)
         {
             if (mCore->layer() == Core::LOWER)
             {
-                if (!mCore->isEblock(mCore->translate(m_lower[_index(x, y)])) &&
-                    !mCore->isAnimation(mCore->translate(m_lower[_index(x, y)])))
-                    m_lower[_index(x,y)] = bind(x, y);
+                if (!mCore->isEblock(mCore->translate(m_lower[static_cast<size_t>(_index(x, y))])) &&
+                    !mCore->isAnimation(mCore->translate(m_lower[static_cast<size_t>(_index(x, y))])))
+                    m_lower[static_cast<size_t>(_index(x,y))] = bind(x, y);
             }
 
         }
@@ -727,9 +728,9 @@ void QGraphicsMapScene::drawPen()
         for (int y = cur_y; y < cur_y + mCore->selHeight(); y++)
         {
             if (mCore->layer() == Core::LOWER)
-                m_lower[_index(x,y)] = mCore->selection(x-fst_x,y-fst_y);
+                m_lower[static_cast<size_t>(_index(x,y))] = mCore->selection(x-fst_x,y-fst_y);
             else if (mCore->layer() == Core::UPPER)
-                m_upper[_index(x,y)] = mCore->selection(x-fst_x,y-fst_y);
+                m_upper[static_cast<size_t>(_index(x,y))] = mCore->selection(x-fst_x,y-fst_y);
         }
     updateArea(cur_x-1,cur_y-1,cur_x+mCore->selWidth()+1,cur_y+mCore->selHeight()+1);
 }
@@ -756,9 +757,9 @@ void QGraphicsMapScene::drawRect()
         for (int y = y1; y <= y2; y++)
         {
             if (mCore->layer() == Core::LOWER)
-                m_lower[_index(x,y)] = mCore->selection(x-fst_x,y-fst_y);
+                m_lower[static_cast<size_t>(_index(x,y))] = mCore->selection(x-fst_x,y-fst_y);
             else if (mCore->layer() == Core::UPPER)
-                m_upper[_index(x,y)] = mCore->selection(x-fst_x,y-fst_y);
+                m_upper[static_cast<size_t>(_index(x,y))] = mCore->selection(x-fst_x,y-fst_y);
         }
     updateArea(x1-2, y1-2, x2+2, y2+2);
 }
@@ -772,14 +773,14 @@ void QGraphicsMapScene::drawFill(int terrain_id, int x, int y)
     switch (mCore->layer())
     {
     case (Core::LOWER):
-        if (mCore->translate(m_lower[_index(x,y)]) != terrain_id)
+        if (mCore->translate(m_lower[static_cast<size_t>(_index(x,y))]) != terrain_id)
             return;
-        m_lower[_index(x,y)] = mCore->selection(x-fst_x,y-fst_y);
+        m_lower[static_cast<size_t>(_index(x,y))] = mCore->selection(x-fst_x,y-fst_y);
         break;
     case (Core::UPPER):
-        if (mCore->translate(m_upper[_index(x,y)]) != terrain_id)
+        if (mCore->translate(m_upper[static_cast<size_t>(_index(x,y))]) != terrain_id)
             return;
-        m_upper[_index(x,y)] = mCore->selection(x-fst_x,y-fst_y);
+        m_upper[static_cast<size_t>(_index(x,y))] = mCore->selection(x-fst_x,y-fst_y);
         break;
     default:
         break;
@@ -792,16 +793,16 @@ void QGraphicsMapScene::drawFill(int terrain_id, int x, int y)
 
 short QGraphicsMapScene::bind(int x, int y)
 {
-#define tile_u mCore->translate(m_lower[_index(x, y-1)])
-#define tile_d mCore->translate(m_lower[_index(x, y+1)])
-#define tile_l mCore->translate(m_lower[_index(x-1, y)])
-#define tile_r mCore->translate(m_lower[_index(x+1, y)])
-#define tile_ul mCore->translate(m_lower[_index(x-1, y-1)])
-#define tile_ur mCore->translate(m_lower[_index(x+1, y-1)])
-#define tile_dl mCore->translate(m_lower[_index(x-1, y+1)])
-#define tile_dr mCore->translate(m_lower[_index(x+1, y+1)])
+#define tile_u mCore->translate(m_lower[static_cast<size_t>(_index(x, y-1))])
+#define tile_d mCore->translate(m_lower[static_cast<size_t>(_index(x, y+1))])
+#define tile_l mCore->translate(m_lower[static_cast<size_t>(_index(x-1, y))])
+#define tile_r mCore->translate(m_lower[static_cast<size_t>(_index(x+1, y))])
+#define tile_ul mCore->translate(m_lower[static_cast<size_t>(_index(x-1, y-1))])
+#define tile_ur mCore->translate(m_lower[static_cast<size_t>(_index(x+1, y-1))])
+#define tile_dl mCore->translate(m_lower[static_cast<size_t>(_index(x-1, y+1))])
+#define tile_dr mCore->translate(m_lower[static_cast<size_t>(_index(x+1, y+1))])
     int _code = 0, _scode = 0;
-    int terrain_id = mCore->translate(m_lower[_index(x, y)]);
+    int terrain_id = mCore->translate(m_lower[static_cast<size_t>(_index(x, y))]);
     int u=0,d=0,l=0,r=0,ul=0,ur=0,dl=0,dr=0,sul=0,sur=0,sdl=0,sdr=0;
     if (mCore->isDblock(terrain_id))
     {

--- a/src/tools/qgraphicsmapscene.h
+++ b/src/tools/qgraphicsmapscene.h
@@ -18,7 +18,7 @@ class QGraphicsMapScene : public QGraphicsScene
 {
     Q_OBJECT
 public:
-    explicit QGraphicsMapScene(int id,QGraphicsView *view, QObject *parent = 0);
+    explicit QGraphicsMapScene(int id,QGraphicsView *view, QObject *parent = nullptr);
     ~QGraphicsMapScene();
 
     void Init();

--- a/src/tools/qgraphicspaletescene.cpp
+++ b/src/tools/qgraphicspaletescene.cpp
@@ -81,10 +81,10 @@ void QGraphicsPaleteScene::onChipsetChange()
 void QGraphicsPaleteScene::updateSelectionRect()
 {
     QRectF selRect;
-    int small_x = (m_initial.x() <= m_current.x()) ? m_initial.x()/32.0 : m_current.x()/32.0;
-    int big_x = (m_initial.x() >= m_current.x()) ? m_initial.x()/32.0 : m_current.x()/32.0;
-    int small_y = (m_initial.y() <= m_current.y()) ? m_initial.y()/32.0 : m_current.y()/32.0;
-    int big_y = (m_initial.y() >= m_current.y()) ? m_initial.y()/32.0 : m_current.y()/32.0;
+    int small_x = (m_initial.x() <= m_current.x()) ? static_cast<int>(m_initial.x())/32 : static_cast<int>(m_current.x())/32;
+    int big_x = (m_initial.x() >= m_current.x()) ? static_cast<int>(m_initial.x())/32 : static_cast<int>(m_current.x())/32;
+    int small_y = (m_initial.y() <= m_current.y()) ? static_cast<int>(m_initial.y())/32 : static_cast<int>(m_current.y())/32;
+    int big_y = (m_initial.y() >= m_current.y()) ? static_cast<int>(m_initial.y())/32 : static_cast<int>(m_current.y())/32;
     //keep inside the scene
     if (small_x < 0)
         small_x = 0;
@@ -98,7 +98,7 @@ void QGraphicsPaleteScene::updateSelectionRect()
         big_y = 27;
     if (big_y - small_y > 5)
     {
-        if ((int)m_initial.y()/32 == small_y)
+        if (static_cast<int>(m_initial.y())/32 == small_y)
             big_y = small_y + 5;
         else
             small_y = big_y - 5;
@@ -153,10 +153,10 @@ void QGraphicsPaleteScene::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
 
     //TODO: set selection
     std::vector<short> sel;
-    int x = m_selectionItem->rect().left()/32.0;
-    int y = m_selectionItem->rect().top()/32.0;
-    int w =  m_selectionItem->rect().width()/32;
-    int h = m_selectionItem->rect().height()/32;
+    int x = static_cast<int>(m_selectionItem->rect().left())/32;
+    int y = static_cast<int>(m_selectionItem->rect().top())/32;
+    int w = static_cast<int>(m_selectionItem->rect().width())/32;
+    int h = static_cast<int>(m_selectionItem->rect().height())/32;
     if (y == 0)
     {
         sel.push_back(NTILE);

--- a/src/tools/qgraphicspaletescene.h
+++ b/src/tools/qgraphicspaletescene.h
@@ -12,7 +12,7 @@ class QGraphicsPaleteScene : public QGraphicsScene
     Q_OBJECT
 public:
 
-    explicit QGraphicsPaleteScene(QObject *parent = 0);
+    explicit QGraphicsPaleteScene(QObject *parent = nullptr);
 
 
 signals:

--- a/src/tools/qgraphicspickerscene.cpp
+++ b/src/tools/qgraphicspickerscene.cpp
@@ -21,10 +21,10 @@ void QGraphicsPickerScene::mousePressEvent(QGraphicsSceneMouseEvent *event)
 {
     if (!sceneRect().contains(event->scenePos()))
         return;
-    int x = event->scenePos().x()/m_selection->rect().width();
-    int y = event->scenePos().y()/m_selection->rect().height();
-    m_selection->setPos(x*(int)m_selection->rect().width(),
-                        y*(int)m_selection->rect().height());
+    int x = static_cast<int>(event->scenePos().x()/m_selection->rect().width());
+    int y = static_cast<int>(event->scenePos().y()/m_selection->rect().height());
+    m_selection->setPos(x*static_cast<int>(m_selection->rect().width()),
+                        y*static_cast<int>(m_selection->rect().height()));
 }
 int QGraphicsPickerScene::columnCount() const
 {
@@ -41,8 +41,8 @@ void QGraphicsPickerScene::setColumnCount(int columnCount)
 
 int QGraphicsPickerScene::index()
 {
-    int x = m_selection->pos().x()/m_selection->rect().width();
-    int y = m_selection->pos().y()/m_selection->rect().height();
+    int x = static_cast<int>(m_selection->pos().x()/m_selection->rect().width());
+    int y = static_cast<int>(m_selection->pos().y()/m_selection->rect().height());
     return (x+y*columnCount());
 }
 

--- a/src/tools/qgraphicspickerscene.h
+++ b/src/tools/qgraphicspickerscene.h
@@ -9,8 +9,8 @@
 class QGraphicsPickerScene : public QGraphicsScene
 {
 public:
-    QGraphicsPickerScene(QObject *parent = 0,
-                         QGraphicsPixmapItem* backgroundItem = 0,
+    QGraphicsPickerScene(QObject *parent = nullptr,
+                         QGraphicsPixmapItem* backgroundItem = nullptr,
                          int rowCount = 1,
                          int columnCount = 1);
 

--- a/src/tools/qundodraw.h
+++ b/src/tools/qundodraw.h
@@ -11,7 +11,7 @@ public:
     explicit QUndoDraw(Core::Layer layer,
                        std::vector<short> data,
                        QGraphicsMapScene *scene,
-                       QUndoCommand *parent = 0);
+                       QUndoCommand *parent = nullptr);
 
     void undo();
 signals:

--- a/src/tools/qundoevent.h
+++ b/src/tools/qundoevent.h
@@ -10,7 +10,7 @@ class QUndoEvent : public QUndoCommand
 public:
     explicit QUndoEvent(RPG::Event data,
                         QGraphicsMapScene *scene,
-                        QUndoCommand *parent = 0);
+                        QUndoCommand *parent = nullptr);
     void undo();
 
 private:

--- a/src/tools/rpgmodel.h
+++ b/src/tools/rpgmodel.h
@@ -9,7 +9,7 @@ template <class DATA>
 class RpgModel : public QAbstractListModel
 {
 public:
-    RpgModel(QObject *parent = 0) : QAbstractListModel(parent), _data(DATA()()) {}
+    RpgModel(QObject *parent = nullptr) : QAbstractListModel(parent), _data(DATA()()) {}
     virtual ~RpgModel() {}
     virtual int rowCount(const QModelIndex & = QModelIndex()) const override { return _data.size(); }
     virtual QVariant data(const QModelIndex &index, int role) const override;

--- a/src/volumebutton.cpp
+++ b/src/volumebutton.cpp
@@ -46,7 +46,7 @@
 #endif
 
 VolumeButton::VolumeButton(QWidget *parent) :
-    QToolButton(parent), menu(0), label(0), slider(0)
+    QToolButton(parent), menu(nullptr), label(nullptr), slider(nullptr)
 {
     setIcon(style()->standardIcon(QStyle::SP_MediaVolume));
     setPopupMode(QToolButton::InstantPopup);

--- a/src/volumebutton.h
+++ b/src/volumebutton.h
@@ -53,7 +53,7 @@ class VolumeButton : public QToolButton
     Q_PROPERTY(int volume READ volume WRITE setVolume NOTIFY volumeChanged)
 
 public:
-    VolumeButton(QWidget *parent = 0);
+    VolumeButton(QWidget *parent = nullptr);
 
     int volume() const;
 


### PR DESCRIPTION
Use breaks in cases and modern casting to make the compiler happy.

Tested with Qt Creator 4.7.1 (Qt 3.11.1) and Clang 7.0.0 / GCC 8.2.1.