### PR TITLE
CMake: Fix Windows build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,9 @@ find_package(Qt5Widgets REQUIRED)
 find_package(Qt5Core REQUIRED)
 find_package(Qt5Multimedia REQUIRED)
 find_package(Qt5Gui REQUIRED)
+if(WIN32)
+	find_package(Qt5WinExtras REQUIRED)
+endif()
 find_package(liblcf REQUIRED)
 
 # Additional include directories
@@ -104,6 +107,10 @@ include_directories(${LIBLCF_INCLUDE_DIRS})
 # Libraries
 list(APPEND EASYRPG_EDITOR_LIBRARIES ${LIBLCF_LIBRARIES})
 list(APPEND EASYRPG_EDITOR_LIBRARIES Qt5::Widgets Qt5::Gui Qt5::Core Qt5::Multimedia)
+if(WIN32)
+	list(APPEND EASYRPG_EDITOR_LIBRARIES Qt5::WinExtras)
+endif()
+
 set(EASYRPG_EDITOR_LIBRARIES_ALL ${EASYRPG_EDITOR_LIBRARIES} "${PROJECT_NAME}_Static")
 
 # Output path


### PR DESCRIPTION
The CMake file is not really modern CMake but because of the low complexity of an editor build compared to a Player build this is fine imo.