### PR TITLE
Work on the core of Event Commands

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,9 @@ add_library(${PROJECT_NAME} STATIC
 	src/ui/commands/change_item_widget.cpp
 	src/ui/commands/change_item_widget.h
 	src/ui/commands/change_item_widget.ui
+	src/ui/commands/change_level_widget.cpp
+	src/ui/commands/change_level_widget.h
+	src/ui/commands/change_level_widget.ui
 	src/ui/commands/change_money_widget.cpp
 	src/ui/commands/change_money_widget.h
 	src/ui/commands/change_money_widget.ui

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.9)
-cmake_policy(SET CMP0091 NEW) # Support MSVC_RUNTIME_LIBRARY
+if(POLICY CMP0091)
+        cmake_policy(SET CMP0091 NEW) # Support MSVC_RUNTIME_LIBRARY
+endif()
 
 project(EasyRPG_Editor VERSION 0.1.0 LANGUAGES CXX)
 
@@ -47,6 +49,8 @@ add_library(${PROJECT_NAME} STATIC
 	src/model/commonevent.h
 	src/model/enemy.cpp
 	src/model/enemy.h
+	src/model/event_command_list.cpp
+	src/model/event_command_list.h
 	src/model/item.cpp
 	src/model/item.h
 	src/model/project.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,6 +203,8 @@ add_library(${PROJECT_NAME} STATIC
 	src/ui/event/battle_page_widget.cpp
 	src/ui/event/battle_page_widget.h
 	src/ui/event/battle_page_widget.ui
+	src/ui/event/event_command_base_widget.cpp
+	src/ui/event/event_command_base_widget.h
 	src/ui/event/event_commands_widget.cpp
 	src/ui/event/event_commands_widget.h
 	src/ui/event/event_dialog.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,9 @@ add_library(${PROJECT_NAME} STATIC
 	src/ui/commands/face_graphics_widget.cpp
 	src/ui/commands/face_graphics_widget.h
 	src/ui/commands/face_graphics_widget.ui
+	src/ui/commands/full_heal_widget.cpp
+	src/ui/commands/full_heal_widget.h
+	src/ui/commands/full_heal_widget.ui
 	src/ui/commands/input_number_widget.cpp
 	src/ui/commands/input_number_widget.h
 	src/ui/commands/input_number_widget.ui
@@ -125,6 +128,8 @@ add_library(${PROJECT_NAME} STATIC
 	src/ui/common/import_image_dialog.ui
 	src/ui/common/import_item.cpp
 	src/ui/common/import_item.h
+	src/ui/common/operand_widget.cpp
+	src/ui/common/operand_widget.h
 	src/ui/common/palette_scene.cpp
 	src/ui/common/palette_scene.h
 	src/ui/common/picker_scene.cpp

--- a/src/common/lcf_widget_binding.cpp
+++ b/src/common/lcf_widget_binding.cpp
@@ -15,9 +15,7 @@
  * along with EasyRPG Editor. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <QCheckBox>
 #include <QLineEdit>
-#include <QGroupBox>
 
 #include "common/dbstring.h"
 #include "lcf_widget_binding.h"
@@ -36,43 +34,16 @@ void LcfWidgetBinding::connect(QWidget* parent, QLineEdit* lineEdit) {
 	QWidget::connect(lineEdit, &QLineEdit::textChanged, parent, callback);
 }
 
-void LcfWidgetBinding::connect(QWidget* parent, QCheckBox* checkBox) {
-	auto callback = [=](){
-		QVariant variant = checkBox->property("ee_data");
-		if (variant.isNull()) {
-			return;
-		}
-
-		auto data = variant.value<LcfObjectHolder<bool>>();
-		data.obj() = checkBox->isChecked();
-	};
-
-	QWidget::connect(checkBox, &QCheckBox::stateChanged, parent, callback);
-}
-
-void LcfWidgetBinding::connect(QWidget* parent, QGroupBox* groupBox) {
-	auto callback = [=](){
-		QVariant variant = groupBox->property("ee_data");
-		if (variant.isNull()) {
-			return;
-		}
-
-		auto data = variant.value<LcfObjectHolder<bool>>();
-		data.obj() = groupBox->isChecked();
-	};
-
-	QWidget::connect(groupBox, &QGroupBox::toggled, parent, callback);
-}
-
 void LcfWidgetBinding::bind(QLineEdit* widget, lcf::DBString& data) {
-        QVariant v;
-        LcfObjectHolder oh(data);
-        v.setValue(oh);
-        widget->setProperty("ee_data", v);
-        SignalBlocker s(widget);
-        widget->setText(ToQString(data));
+	QVariant v;
+	LcfObjectHolder oh(data);
+	v.setValue(oh);
+	widget->setProperty("ee_data", v);
+	SignalBlocker s(widget);
+	widget->setText(ToQString(data));
 }
 
+template<>
 void LcfWidgetBinding::bind(QCheckBox* widget, bool& data) {
 	QVariant v;
 	LcfObjectHolder oh(data);
@@ -82,6 +53,7 @@ void LcfWidgetBinding::bind(QCheckBox* widget, bool& data) {
 	widget->setChecked(data);
 }
 
+template<>
 void LcfWidgetBinding::bind(QGroupBox* widget, bool& data) {
 	QVariant v;
 	LcfObjectHolder oh(data);

--- a/src/model/event_command_list.cpp
+++ b/src/model/event_command_list.cpp
@@ -1,0 +1,53 @@
+/*
+ * This file is part of EasyRPG Editor.
+ *
+ * EasyRPG Editor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Editor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Editor. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "event_command_list.h"
+
+EventCommandList::EventCommandList(std::vector<lcf::rpg::EventCommand>& commands, int current_index) :
+	m_commands(&commands), m_current_index(current_index)
+{
+	// no-op
+}
+
+std::vector<lcf::rpg::EventCommand>& EventCommandList::commands() {
+	assert(m_commands);
+	return *m_commands;
+}
+
+const std::vector<lcf::rpg::EventCommand>& EventCommandList::commands() const {
+	assert(m_commands);
+	return *m_commands;
+}
+
+lcf::rpg::EventCommand& EventCommandList::command() {
+	assert(m_commands);
+	return (*m_commands)[m_current_index];
+}
+
+const lcf::rpg::EventCommand &EventCommandList::command() const {
+	assert(m_commands);
+	return (*m_commands)[m_current_index];
+}
+
+size_t EventCommandList::size() const {
+	assert(m_commands);
+	return m_commands->size();
+}
+
+int EventCommandList::index() const {
+	return m_current_index;
+}

--- a/src/model/event_command_list.h
+++ b/src/model/event_command_list.h
@@ -17,25 +17,25 @@
 
 #pragma once
 
-#include "ui/event/event_command_base_widget.h"
+#include <lcf/rpg/eventcommand.h>
+#include <vector>
 
-namespace Ui {
-class ShowMessageWidget;
-}
-
-class ShowMessageWidget : public EventCommandBaseWidget
-{
-	Q_OBJECT
-
+class EventCommandList {
 public:
-	explicit ShowMessageWidget(ProjectData& project, QWidget* parent);
-	~ShowMessageWidget();
+	EventCommandList() {};
+	EventCommandList(std::vector<lcf::rpg::EventCommand>& commands, int current_index);
 
-	void setData(EventCommandList* commands) override;
+	std::vector<lcf::rpg::EventCommand>& commands();
+	const std::vector<lcf::rpg::EventCommand>& commands() const;
 
-	void apply();
+	lcf::rpg::EventCommand& command();
+	const lcf::rpg::EventCommand& command() const;
+
+	size_t size() const;
+
+	int index() const;
 
 private:
-	Ui::ShowMessageWidget *ui;
+	std::vector<lcf::rpg::EventCommand>* m_commands = nullptr;
+	int m_current_index = 0;
 };
-

--- a/src/ui/commands/all_commands.h
+++ b/src/ui/commands/all_commands.h
@@ -19,6 +19,7 @@
 #include "change_item_widget.h"
 #include "change_party_widget.h"
 #include "change_experience_widget.h"
+#include "full_heal_widget.h"
 #include "message_options_widget.h"
 #include "face_graphics_widget.h"
 #include "input_number_widget.h"

--- a/src/ui/commands/all_commands.h
+++ b/src/ui/commands/all_commands.h
@@ -17,6 +17,7 @@
 
 #include "change_money_widget.h"
 #include "change_item_widget.h"
+#include "change_level_widget.h"
 #include "change_party_widget.h"
 #include "change_experience_widget.h"
 #include "full_heal_widget.h"

--- a/src/ui/commands/change_experience_widget.cpp
+++ b/src/ui/commands/change_experience_widget.cpp
@@ -18,64 +18,18 @@
 #include "change_experience_widget.h"
 #include "ui_change_experience_widget.h"
 
-ChangeExperienceWidget::ChangeExperienceWidget(QWidget *parent, lcf::rpg::EventCommand &cmd) :
-	QDialog(parent),
-	ui(new Ui::ChangeExperienceWidget),
-	cmd(cmd)
-{
+ChangeExperienceWidget::ChangeExperienceWidget(ProjectData& project, QWidget *parent) :
+	EventCommandBaseWidget(project, parent),
+	ui(new Ui::ChangeExperienceWidget) {
+
 	ui->setupUi(this);
 
-	if (cmd.parameters[0] == 0)
-		ui->target_box_entire->setChecked(true);
-	else if (cmd.parameters[0] == 1)
-	{
-		ui->target_box_specific->setChecked(true);
-		ui->target_specific->setCurrentIndex(cmd.parameters[1]);
+	int i = 0;
+	for (auto& button : { ui->radioInc, ui->radioDec }) {
+		ui->groupOp_arg2->setId(button, i++);
 	}
-	else if (cmd.parameters[0] == 2)
-	{
-		ui->target_box_variable->setChecked(true);
-		ui->target_variable->setCurrentIndex(cmd.parameters[1]);
-	}
-
-	(cmd.parameters[2] ? ui->op_dec : ui->op_inc)->setChecked(true);
-
-	if (cmd.parameters[3] == 0)
-	{
-		ui->amount_fixed->setValue(cmd.parameters[4]);
-		ui->amount_box_fixed->setChecked(true);
-	}
-	else
-	{
-		ui->amount_variable->setCurrentIndex(cmd.parameters[4]);
-		ui->amount_box_variable->setChecked(true);
-	}
-
-	ui->option_show->setChecked(cmd.parameters[5]);
 }
 
-ChangeExperienceWidget::~ChangeExperienceWidget()
-{
+ChangeExperienceWidget::~ChangeExperienceWidget() {
 	delete ui;
-}
-
-void ChangeExperienceWidget::on_ChangeExperienceWidget_accepted()
-{
-	if (ui->target_box_entire->isChecked())
-		cmd.parameters[0] = 0;
-	else if (ui->target_box_specific->isChecked())
-	{
-		cmd.parameters[0] = 1;
-		cmd.parameters[1] = ui->target_specific->currentIndex();
-	}
-	else
-	{
-		cmd.parameters[0] = 2;
-		cmd.parameters[1] = ui->target_variable->currentIndex();
-	}
-
-	cmd.parameters[2] = ui->op_dec->isChecked();
-	cmd.parameters[3] = ui->amount_box_variable->isChecked() ? 1 : 0;
-	cmd.parameters[4] = ui->amount_box_variable->isChecked() ? ui->amount_variable->currentIndex() : ui->amount_fixed->value();
-	cmd.parameters[5] = ui->option_show->isChecked();
 }

--- a/src/ui/commands/change_experience_widget.cpp
+++ b/src/ui/commands/change_experience_widget.cpp
@@ -33,3 +33,9 @@ ChangeExperienceWidget::ChangeExperienceWidget(ProjectData& project, QWidget *pa
 ChangeExperienceWidget::~ChangeExperienceWidget() {
 	delete ui;
 }
+
+void ChangeExperienceWidget::on_EventWidget_parameterChanged(int index, int new_value) {
+	if (index == 2) {
+		ui->check_arg5->setEnabled(new_value == 0);
+	}
+}

--- a/src/ui/commands/change_experience_widget.h
+++ b/src/ui/commands/change_experience_widget.h
@@ -17,26 +17,20 @@
 
 #pragma once
 
-#include <QDialog>
-#include <lcf/rpg/eventcommand.h>
+#include "ui/event/event_command_base_widget.h"
 
 namespace Ui {
 class ChangeExperienceWidget;
 }
 
-class ChangeExperienceWidget : public QDialog
+class ChangeExperienceWidget : public EventCommandBaseWidget
 {
 	Q_OBJECT
 
 public:
-	explicit ChangeExperienceWidget(QWidget *parent, lcf::rpg::EventCommand &cmd);
+	explicit ChangeExperienceWidget(ProjectData& project, QWidget *parent);
 	~ChangeExperienceWidget();
-
-private slots:
-	void on_ChangeExperienceWidget_accepted();
 
 private:
 	Ui::ChangeExperienceWidget *ui;
-	lcf::rpg::EventCommand &cmd;
 };
-

--- a/src/ui/commands/change_experience_widget.h
+++ b/src/ui/commands/change_experience_widget.h
@@ -33,4 +33,7 @@ public:
 
 private:
 	Ui::ChangeExperienceWidget *ui;
+
+private slots:
+	void on_EventWidget_parameterChanged(int index, int new_value);
 };

--- a/src/ui/commands/change_item_widget.cpp
+++ b/src/ui/commands/change_item_widget.cpp
@@ -18,48 +18,25 @@
 #include "change_item_widget.h"
 #include "ui_change_item_widget.h"
 
-ChangeItemWidget::ChangeItemWidget(QWidget *parent, lcf::rpg::EventCommand &cmd) :
-	QDialog(parent),
-	ui(new Ui::ChangeItemWidget),
-	cmd(cmd)
-{
+ChangeItemWidget::ChangeItemWidget(ProjectData& project, QWidget *parent) :
+	EventCommandBaseWidget(project, parent),
+	ui(new Ui::ChangeItemWidget) {
+
 	ui->setupUi(this);
 
-	(cmd.parameters[0] ? ui->op_rem : ui->op_add)->setChecked(true);
-
-	if (cmd.parameters[1] == 0)
-	{
-		ui->item_item->setCurrentIndex(cmd.parameters[2]);
-		ui->item_box_item->setChecked(true);
-	}
-	else
-	{
-		ui->item_variable->setCurrentIndex(cmd.parameters[2]);
-		ui->item_box_variable->setChecked(true);
-	}
-
-	if (cmd.parameters[3] == 0)
-	{
-		ui->amount_amount->setValue(cmd.parameters[4]);
-		ui->amount_box_fix->setChecked(true);
-	}
-	else
-	{
-		ui->amount_variable->setCurrentIndex(cmd.parameters[4]);
-		ui->amount_box_variable->setChecked(true);
+	int i = 0;
+	for (auto& button : { ui->radioOpAdd, ui->radioOpRemove }) {
+		ui->groupOp_arg0->setId(button, i++);
 	}
 }
 
-ChangeItemWidget::~ChangeItemWidget()
-{
+ChangeItemWidget::~ChangeItemWidget() {
 	delete ui;
 }
 
-void ChangeItemWidget::on_ChangeItemWidget_accepted()
-{
-	cmd.parameters[0] = ui->op_rem->isChecked() ? 1 : 0;
-	cmd.parameters[1] = ui->item_box_variable->isChecked() ? 1 : 0;
-	cmd.parameters[2] = ui->item_box_variable->isChecked() ? ui->item_variable->currentIndex() : ui->item_item->currentIndex();
-	cmd.parameters[3] = ui->amount_box_variable->isChecked() ? 1 : 0;
-	cmd.parameters[4] = ui->amount_box_variable->isChecked() ? ui->amount_variable->currentIndex() : ui->amount_amount->value();
+void ChangeItemWidget::setData(lcf::rpg::EventCommand* cmd) {
+	EventCommandBaseWidget::setData(cmd);
+
+	ui->operandAmount->attach(m_project, *cmd, 3, 4);
+	ui->operandItem->attach(m_project, *cmd, 1, 2);
 }

--- a/src/ui/commands/change_item_widget.h
+++ b/src/ui/commands/change_item_widget.h
@@ -31,8 +31,6 @@ public:
 	explicit ChangeItemWidget(ProjectData& project, QWidget *parent);
 	~ChangeItemWidget();
 
-	virtual void setData(lcf::rpg::EventCommand* cmd) override;
-
 private:
 	Ui::ChangeItemWidget *ui;
 };

--- a/src/ui/commands/change_item_widget.ui
+++ b/src/ui/commands/change_item_widget.ui
@@ -1,275 +1,97 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>ChangeItemWidget</class>
- <widget class="QDialog" name="ChangeItemWidget">
-  <property name="windowModality">
-   <enum>Qt::WindowModal</enum>
-  </property>
+ <widget class="QWidget" name="ChangeItemWidget">
   <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
     <width>486</width>
-    <height>385</height>
+    <height>434</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Change item</string>
   </property>
-  <property name="modal">
-   <bool>true</bool>
-  </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QFrame" name="frame">
-     <property name="frameShape">
-      <enum>QFrame::StyledPanel</enum>
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Operation</string>
      </property>
-     <property name="frameShadow">
-      <enum>QFrame::Raised</enum>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout_2">
+     <layout class="QHBoxLayout" name="horizontalLayout">
       <item>
-       <widget class="QGroupBox" name="groupBox">
-        <property name="title">
-         <string>Operation</string>
+       <widget class="QRadioButton" name="radioOpAdd">
+        <property name="text">
+         <string>Add item</string>
         </property>
-        <layout class="QHBoxLayout" name="horizontalLayout">
-         <item>
-          <widget class="QRadioButton" name="op_add">
-           <property name="text">
-            <string>Add item</string>
-           </property>
-           <property name="checked">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QRadioButton" name="op_rem">
-           <property name="text">
-            <string>Remo&amp;ve item</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+        <attribute name="buttonGroup">
+         <string notr="true">groupOp_arg0</string>
+        </attribute>
        </widget>
       </item>
       <item>
-       <widget class="QGroupBox" name="groupBox_2">
-        <property name="title">
-         <string>Select item</string>
+       <widget class="QRadioButton" name="radioOpRemove">
+        <property name="text">
+         <string>Remo&amp;ve item</string>
         </property>
-        <layout class="QFormLayout" name="formLayout">
-         <item row="0" column="0">
-          <widget class="QRadioButton" name="item_box_item">
-           <property name="text">
-            <string>Specific item</string>
-           </property>
-           <property name="checked">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="ItemRpgComboBox" name="item_item"/>
-         </item>
-         <item row="1" column="0">
-          <widget class="QRadioButton" name="item_box_variable">
-           <property name="text">
-            <string>Item with ID stored in</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="1">
-          <widget class="VariableRpgComboBox" name="item_variable">
-           <property name="enabled">
-            <bool>false</bool>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item>
-       <widget class="QGroupBox" name="groupBox_3">
-        <property name="title">
-         <string>Amount</string>
-        </property>
-        <layout class="QFormLayout" name="formLayout_2">
-         <item row="0" column="0">
-          <widget class="QRadioButton" name="amount_box_fix">
-           <property name="text">
-            <string>Fi&amp;xed amount</string>
-           </property>
-           <property name="checked">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="QSpinBox" name="amount_amount"/>
-         </item>
-         <item row="1" column="0">
-          <widget class="QRadioButton" name="amount_box_variable">
-           <property name="text">
-            <string>A&amp;mount stored in</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="1">
-          <widget class="VariableRpgComboBox" name="amount_variable">
-           <property name="enabled">
-            <bool>false</bool>
-           </property>
-          </widget>
-         </item>
-        </layout>
+        <attribute name="buttonGroup">
+         <string notr="true">groupOp_arg0</string>
+        </attribute>
        </widget>
       </item>
      </layout>
     </widget>
    </item>
    <item>
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+    <widget class="QGroupBox" name="groupBox_2">
+     <property name="title">
+      <string>Select item</string>
      </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="0" column="0">
+       <widget class="ItemOperandWidget" name="operandItem" native="true"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="groupBox_3">
+     <property name="title">
+      <string>Amount</string>
      </property>
+     <layout class="QGridLayout" name="gridLayout_2">
+      <item row="0" column="1">
+       <widget class="ValueOperandWidget" name="operandAmount" native="true"/>
+      </item>
+     </layout>
     </widget>
    </item>
   </layout>
  </widget>
  <customwidgets>
   <customwidget>
-   <class>VariableRpgComboBox</class>
-   <extends>QComboBox</extends>
-   <header>ui/common/rpg_combobox.h</header>
+   <class>ItemOperandWidget</class>
+   <extends>QWidget</extends>
+   <header>ui/common/operand_widget.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
-   <class>ItemRpgComboBox</class>
-   <extends>QComboBox</extends>
-   <header>ui/common/rpg_combobox.h</header>
+   <class>ValueOperandWidget</class>
+   <extends>QWidget</extends>
+   <header>ui/common/operand_widget.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <resources/>
- <connections>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>accepted()</signal>
-   <receiver>ChangeItemWidget</receiver>
-   <slot>accept()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>248</x>
-     <y>254</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>157</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>rejected()</signal>
-   <receiver>ChangeItemWidget</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>316</x>
-     <y>260</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>286</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>helpRequested()</signal>
-   <receiver>ChangeItemWidget</receiver>
-   <slot>helpRequested()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>200</x>
-     <y>255</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>199</x>
-     <y>149</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>item_box_item</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>item_item</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>83</x>
-     <y>136</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>328</x>
-     <y>136</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>item_box_variable</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>item_variable</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>113</x>
-     <y>167</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>328</x>
-     <y>167</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>amount_box_fix</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>amount_amount</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>87</x>
-     <y>241</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>313</x>
-     <y>241</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>amount_box_variable</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>amount_variable</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>98</x>
-     <y>273</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>313</x>
-     <y>273</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
  <slots>
   <slot>helpRequested()</slot>
  </slots>
+ <buttongroups>
+  <buttongroup name="groupOp_arg0"/>
+ </buttongroups>
 </ui>

--- a/src/ui/commands/change_item_widget.ui
+++ b/src/ui/commands/change_item_widget.ui
@@ -53,7 +53,7 @@
      </property>
      <layout class="QGridLayout" name="gridLayout">
       <item row="0" column="0">
-       <widget class="ItemOperandWidget" name="operandItem" native="true"/>
+       <widget class="ItemOperandWidget" name="operandItem_arg1" native="true"/>
       </item>
      </layout>
     </widget>
@@ -65,7 +65,7 @@
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
       <item row="0" column="1">
-       <widget class="ValueOperandWidget" name="operandAmount" native="true"/>
+       <widget class="ValueOperandWidget" name="operandAmount_arg3" native="true"/>
       </item>
      </layout>
     </widget>

--- a/src/ui/commands/change_level_widget.cpp
+++ b/src/ui/commands/change_level_widget.cpp
@@ -33,3 +33,9 @@ ChangeLevelWidget::ChangeLevelWidget(ProjectData& project, QWidget *parent) :
 ChangeLevelWidget::~ChangeLevelWidget() {
 	delete ui;
 }
+
+void ChangeLevelWidget::on_EventWidget_parameterChanged(int index, int new_value) {
+	if (index == 2) {
+		ui->check_arg5->setEnabled(new_value == 0);
+	}
+}

--- a/src/ui/commands/change_level_widget.cpp
+++ b/src/ui/commands/change_level_widget.cpp
@@ -15,21 +15,21 @@
  * along with EasyRPG Editor. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "change_item_widget.h"
-#include "ui_change_item_widget.h"
+#include "change_level_widget.h"
+#include "ui_change_level_widget.h"
 
-ChangeItemWidget::ChangeItemWidget(ProjectData& project, QWidget *parent) :
+ChangeLevelWidget::ChangeLevelWidget(ProjectData& project, QWidget *parent) :
 	EventCommandBaseWidget(project, parent),
-	ui(new Ui::ChangeItemWidget) {
+	ui(new Ui::ChangeLevelWidget) {
 
 	ui->setupUi(this);
 
 	int i = 0;
-	for (auto& button : { ui->radioOpAdd, ui->radioOpRemove }) {
-		ui->groupOp_arg0->setId(button, i++);
+	for (auto& button : { ui->radioInc, ui->radioDec }) {
+		ui->groupOp_arg2->setId(button, i++);
 	}
 }
 
-ChangeItemWidget::~ChangeItemWidget() {
+ChangeLevelWidget::~ChangeLevelWidget() {
 	delete ui;
 }

--- a/src/ui/commands/change_level_widget.h
+++ b/src/ui/commands/change_level_widget.h
@@ -15,21 +15,22 @@
  * along with EasyRPG Editor. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "change_item_widget.h"
-#include "ui_change_item_widget.h"
+#pragma once
 
-ChangeItemWidget::ChangeItemWidget(ProjectData& project, QWidget *parent) :
-	EventCommandBaseWidget(project, parent),
-	ui(new Ui::ChangeItemWidget) {
+#include "ui/event/event_command_base_widget.h"
 
-	ui->setupUi(this);
-
-	int i = 0;
-	for (auto& button : { ui->radioOpAdd, ui->radioOpRemove }) {
-		ui->groupOp_arg0->setId(button, i++);
-	}
+namespace Ui {
+class ChangeLevelWidget;
 }
 
-ChangeItemWidget::~ChangeItemWidget() {
-	delete ui;
-}
+class ChangeLevelWidget : public EventCommandBaseWidget
+{
+	Q_OBJECT
+
+public:
+	explicit ChangeLevelWidget(ProjectData& project, QWidget *parent);
+	~ChangeLevelWidget();
+
+private:
+	Ui::ChangeLevelWidget *ui;
+};

--- a/src/ui/commands/change_level_widget.h
+++ b/src/ui/commands/change_level_widget.h
@@ -33,4 +33,7 @@ public:
 
 private:
 	Ui::ChangeLevelWidget *ui;
+
+private slots:
+	void on_EventWidget_parameterChanged(int index, int new_value);
 };

--- a/src/ui/commands/change_level_widget.ui
+++ b/src/ui/commands/change_level_widget.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>ChangeExperienceWidget</class>
- <widget class="QWidget" name="ChangeExperienceWidget">
+ <class>ChangeLevelWidget</class>
+ <widget class="QWidget" name="ChangeLevelWidget">
   <property name="geometry">
    <rect>
     <x>0</x>

--- a/src/ui/commands/command_definitions.h
+++ b/src/ui/commands/command_definitions.h
@@ -1,0 +1,7 @@
+//
+// Created by gabriel on 18/08/20.
+//
+
+#pragma once
+
+#include <KPropertySet>

--- a/src/ui/commands/full_heal_widget.cpp
+++ b/src/ui/commands/full_heal_widget.cpp
@@ -15,24 +15,22 @@
  * along with EasyRPG Editor. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#pragma once
+#include "full_heal_widget.h"
+#include "ui_full_heal_widget.h"
 
-#include "ui/event/event_command_base_widget.h"
-
-namespace Ui {
-class ChangeItemWidget;
+FullHealWidget::FullHealWidget(ProjectData& project, QWidget *parent) :
+	EventCommandBaseWidget(project, parent),
+	ui(new Ui::FullHealWidget)
+{
+	ui->setupUi(this);
 }
 
-class ChangeItemWidget : public EventCommandBaseWidget
-{
-	Q_OBJECT
+FullHealWidget::~FullHealWidget() {
+	delete ui;
+}
 
-public:
-	explicit ChangeItemWidget(ProjectData& project, QWidget *parent);
-	~ChangeItemWidget();
+void FullHealWidget::setData(lcf::rpg::EventCommand* cmd) {
+	EventCommandBaseWidget::setData(cmd);
 
-	virtual void setData(lcf::rpg::EventCommand* cmd) override;
-
-private:
-	Ui::ChangeItemWidget *ui;
-};
+	ui->operandParty->attach(m_project, *cmd, 0, 1);
+}

--- a/src/ui/commands/full_heal_widget.cpp
+++ b/src/ui/commands/full_heal_widget.cpp
@@ -28,9 +28,3 @@ FullHealWidget::FullHealWidget(ProjectData& project, QWidget *parent) :
 FullHealWidget::~FullHealWidget() {
 	delete ui;
 }
-
-void FullHealWidget::setData(lcf::rpg::EventCommand* cmd) {
-	EventCommandBaseWidget::setData(cmd);
-
-	ui->operandParty->attach(m_project, *cmd, 0, 1);
-}

--- a/src/ui/commands/full_heal_widget.h
+++ b/src/ui/commands/full_heal_widget.h
@@ -20,19 +20,19 @@
 #include "ui/event/event_command_base_widget.h"
 
 namespace Ui {
-class ChangeItemWidget;
+class FullHealWidget;
 }
 
-class ChangeItemWidget : public EventCommandBaseWidget
+class FullHealWidget : public EventCommandBaseWidget
 {
 	Q_OBJECT
 
 public:
-	explicit ChangeItemWidget(ProjectData& project, QWidget *parent);
-	~ChangeItemWidget();
+	explicit FullHealWidget(ProjectData& project, QWidget *parent);
+	~FullHealWidget();
 
 	virtual void setData(lcf::rpg::EventCommand* cmd) override;
 
 private:
-	Ui::ChangeItemWidget *ui;
+	Ui::FullHealWidget* ui;
 };

--- a/src/ui/commands/full_heal_widget.h
+++ b/src/ui/commands/full_heal_widget.h
@@ -31,8 +31,6 @@ public:
 	explicit FullHealWidget(ProjectData& project, QWidget *parent);
 	~FullHealWidget();
 
-	virtual void setData(lcf::rpg::EventCommand* cmd) override;
-
 private:
 	Ui::FullHealWidget* ui;
 };

--- a/src/ui/commands/full_heal_widget.ui
+++ b/src/ui/commands/full_heal_widget.ui
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>FullHealWidget</class>
+ <widget class="QWidget" name="FullHealWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Actor</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_2">
+      <item row="0" column="0">
+       <widget class="PartyOperandWidget" name="operandParty" native="true"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>PartyOperandWidget</class>
+   <extends>QWidget</extends>
+   <header>ui/common/operand_widget.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/ui/commands/full_heal_widget.ui
+++ b/src/ui/commands/full_heal_widget.ui
@@ -21,7 +21,7 @@
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
       <item row="0" column="0">
-       <widget class="PartyOperandWidget" name="operandParty" native="true"/>
+       <widget class="PartyOperandWidget" name="operandParty_arg0" native="true"/>
       </item>
      </layout>
     </widget>

--- a/src/ui/commands/input_number_widget.cpp
+++ b/src/ui/commands/input_number_widget.cpp
@@ -18,17 +18,15 @@
 #include "input_number_widget.h"
 #include "ui_input_number_widget.h"
 
-InputNumberWidget::InputNumberWidget(QWidget *parent, lcf::rpg::EventCommand &cmd) :
-	QDialog(parent),
-	ui(new Ui::InputNumberWidget),
-	cmd(cmd)
-{
+InputNumberWidget::InputNumberWidget(ProjectData& project, QWidget *parent) :
+	EventCommandBaseWidget(project, parent),
+	ui(new Ui::InputNumberWidget) {
+
 	ui->setupUi(this);
 
-	//TODO
+	ui->comboVariable_arg1->makeModel(project);
 }
 
-InputNumberWidget::~InputNumberWidget()
-{
+InputNumberWidget::~InputNumberWidget() {
 	delete ui;
 }

--- a/src/ui/commands/input_number_widget.h
+++ b/src/ui/commands/input_number_widget.h
@@ -17,26 +17,20 @@
 
 #pragma once
 
-#include <QDialog>
-#include <lcf/rpg/eventcommand.h>
+#include <ui/event/event_command_base_widget.h>
 
 namespace Ui {
 class InputNumberWidget;
 }
 
-class InputNumberWidget : public QDialog
+class InputNumberWidget : public EventCommandBaseWidget
 {
 	Q_OBJECT
 
 public:
-	explicit InputNumberWidget(QWidget *parent, lcf::rpg::EventCommand &cmd);
+	explicit InputNumberWidget(ProjectData& project, QWidget *parent);
 	~InputNumberWidget();
-
-private slots:
-
 
 private:
 	Ui::InputNumberWidget *ui;
-	lcf::rpg::EventCommand &cmd;
 };
-

--- a/src/ui/commands/input_number_widget.ui
+++ b/src/ui/commands/input_number_widget.ui
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>InputNumberWidget</class>
- <widget class="QDialog" name="InputNumberWidget">
-  <property name="windowModality">
-   <enum>Qt::WindowModal</enum>
+ <widget class="QWidget" name="InputNumberWidget">
+  <property name="modal" stdset="0">
+   <bool>false</bool>
   </property>
   <property name="geometry">
    <rect>
@@ -15,9 +15,6 @@
   </property>
   <property name="windowTitle">
    <string>Input Number</string>
-  </property>
-  <property name="modal">
-   <bool>true</bool>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
@@ -36,7 +33,7 @@
         </property>
         <layout class="QVBoxLayout" name="verticalLayout_2">
          <item>
-          <widget class="QSpinBox" name="allowed_digits">
+          <widget class="QSpinBox" name="spinDigits_arg0">
            <property name="showGroupSeparator" stdset="0">
             <bool>false</bool>
            </property>
@@ -61,25 +58,12 @@
         </property>
         <layout class="QHBoxLayout" name="horizontalLayout_2">
          <item>
-          <widget class="VariableRpgComboBox" name="variable_box"/>
+          <widget class="VariableRpgComboBox" name="comboVariable_arg1"/>
          </item>
         </layout>
        </widget>
       </item>
      </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
-     </property>
-     <property name="centerButtons">
-      <bool>false</bool>
-     </property>
     </widget>
    </item>
   </layout>
@@ -92,56 +76,7 @@
   </customwidget>
  </customwidgets>
  <resources/>
- <connections>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>accepted()</signal>
-   <receiver>InputNumberWidget</receiver>
-   <slot>accept()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>248</x>
-     <y>254</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>157</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>rejected()</signal>
-   <receiver>InputNumberWidget</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>316</x>
-     <y>260</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>286</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>helpRequested()</signal>
-   <receiver>InputNumberWidget</receiver>
-   <slot>helpRequest()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>298</x>
-     <y>204</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>298</x>
-     <y>113</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
  <slots>
   <slot>helpRequest()</slot>
   <slot>textChanged()</slot>

--- a/src/ui/commands/message_options_widget.cpp
+++ b/src/ui/commands/message_options_widget.cpp
@@ -18,17 +18,23 @@
 #include "message_options_widget.h"
 #include "ui_message_options_widget.h"
 
-MessageOptionsWidget::MessageOptionsWidget(QWidget *parent, lcf::rpg::EventCommand &command) :
-	QDialog(parent),
-	ui(new Ui::MessageOptionsWidget),
-	command(command)
-{
+MessageOptionsWidget::MessageOptionsWidget(ProjectData& project, QWidget *parent) :
+	EventCommandBaseWidget(project, parent),
+	ui(new Ui::MessageOptionsWidget) {
+
 	ui->setupUi(this);
 
-	//TODO
+	int i = 0;
+	for (auto& button : { ui->buttonTypeNormal, ui->buttonTypeTransparent }) {
+		ui->groupWindowType_arg0->setId(button, i++);
+	}
+
+	i = 0;
+	for (auto& button : { ui->buttonPositionTop, ui->buttonPositionMiddle, ui->buttonPositionBottom }) {
+		ui->groupWindowPos_arg1->setId(button, i++);
+	}
 }
 
-MessageOptionsWidget::~MessageOptionsWidget()
-{
+MessageOptionsWidget::~MessageOptionsWidget() {
 	delete ui;
 }

--- a/src/ui/commands/message_options_widget.h
+++ b/src/ui/commands/message_options_widget.h
@@ -17,23 +17,20 @@
 
 #pragma once
 
-#include <QDialog>
-#include <lcf/rpg/eventcommand.h>
+#include <ui/event/event_command_base_widget.h>
 
 namespace Ui {
 class MessageOptionsWidget;
 }
 
-class MessageOptionsWidget : public QDialog
+class MessageOptionsWidget : public EventCommandBaseWidget
 {
 	Q_OBJECT
 
 public:
-	explicit MessageOptionsWidget(QWidget *parent, lcf::rpg::EventCommand &command);
+	explicit MessageOptionsWidget(ProjectData& project, QWidget *parent);
 	~MessageOptionsWidget();
 
 private:
 	Ui::MessageOptionsWidget *ui;
-	lcf::rpg::EventCommand &command;
 };
-

--- a/src/ui/commands/message_options_widget.ui
+++ b/src/ui/commands/message_options_widget.ui
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>MessageOptionsWidget</class>
- <widget class="QDialog" name="MessageOptionsWidget">
-  <property name="windowModality">
-   <enum>Qt::WindowModal</enum>
-  </property>
+ <widget class="QWidget" name="MessageOptionsWidget">
   <property name="geometry">
    <rect>
     <x>0</x>
@@ -16,182 +13,124 @@
   <property name="windowTitle">
    <string>Message Options</string>
   </property>
-  <property name="modal">
-   <bool>true</bool>
-  </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
-   <item>
-    <widget class="QFrame" name="frame">
-     <property name="frameShape">
-      <enum>QFrame::StyledPanel</enum>
-     </property>
-     <property name="frameShadow">
-      <enum>QFrame::Raised</enum>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout_2">
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout">
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QGroupBox" name="groupBox">
+       <property name="title">
+        <string>Window type</string>
+       </property>
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
         <item>
-         <widget class="QGroupBox" name="groupBox">
-          <property name="title">
-           <string>Window type</string>
+         <widget class="QRadioButton" name="buttonTypeNormal">
+          <property name="text">
+           <string>Normal</string>
           </property>
-          <layout class="QHBoxLayout" name="horizontalLayout_2">
-           <item>
-            <widget class="QRadioButton" name="type_normal">
-             <property name="text">
-              <string>Normal</string>
-             </property>
-             <property name="checked">
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QRadioButton" name="type_transparent">
-             <property name="text">
-              <string>Transparent</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+          <attribute name="buttonGroup">
+           <string notr="true">groupWindowType_arg0</string>
+          </attribute>
          </widget>
         </item>
         <item>
-         <widget class="QGroupBox" name="groupBox_2">
-          <property name="title">
-           <string>Window position</string>
+         <widget class="QRadioButton" name="buttonTypeTransparent">
+          <property name="text">
+           <string>Transparent</string>
           </property>
-          <layout class="QHBoxLayout" name="horizontalLayout_3">
-           <item>
-            <widget class="QRadioButton" name="position_top">
-             <property name="text">
-              <string>Top</string>
-             </property>
-             <property name="checked">
-              <bool>false</bool>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QRadioButton" name="position_mid">
-             <property name="text">
-              <string>Middle</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QRadioButton" name="position_bot">
-             <property name="text">
-              <string>Bottom</string>
-             </property>
-             <property name="checked">
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
-          </layout>
+          <attribute name="buttonGroup">
+           <string notr="true">groupWindowType_arg0</string>
+          </attribute>
          </widget>
         </item>
        </layout>
+      </widget>
+     </item>
+     <item>
+      <widget class="QGroupBox" name="groupBox_2">
+       <property name="title">
+        <string>Window position</string>
+       </property>
+       <layout class="QHBoxLayout" name="horizontalLayout_3">
+        <item>
+         <widget class="QRadioButton" name="buttonPositionTop">
+          <property name="text">
+           <string>Top</string>
+          </property>
+          <property name="checked">
+           <bool>false</bool>
+          </property>
+          <attribute name="buttonGroup">
+           <string notr="true">groupWindowPos_arg1</string>
+          </attribute>
+         </widget>
+        </item>
+        <item>
+         <widget class="QRadioButton" name="buttonPositionMiddle">
+          <property name="text">
+           <string>Middle</string>
+          </property>
+          <attribute name="buttonGroup">
+           <string notr="true">groupWindowPos_arg1</string>
+          </attribute>
+         </widget>
+        </item>
+        <item>
+         <widget class="QRadioButton" name="buttonPositionBottom">
+          <property name="text">
+           <string>Bottom</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+          <attribute name="buttonGroup">
+           <string notr="true">groupWindowPos_arg1</string>
+          </attribute>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="1" column="0">
+    <widget class="QGroupBox" name="groupBox_3">
+     <property name="title">
+      <string>Options</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_3">
+      <item>
+       <widget class="QCheckBox" name="checkPos_arg2">
+        <property name="text">
+         <string>Autoselect window position to prevent hero from being obscure</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
       </item>
       <item>
-       <widget class="QGroupBox" name="groupBox_3">
-        <property name="title">
-         <string>Options</string>
+       <widget class="QCheckBox" name="checkParallel_arg3">
+        <property name="text">
+         <string>Allow other events to continue while message is shown</string>
         </property>
-        <layout class="QVBoxLayout" name="verticalLayout_3">
-         <item>
-          <widget class="QCheckBox" name="option_autopos">
-           <property name="text">
-            <string>Autoselect window position to prevent hero from being obscure</string>
-           </property>
-           <property name="checked">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QCheckBox" name="option_parallel">
-           <property name="text">
-            <string>Allow other events to continue while message is shown</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
        </widget>
       </item>
      </layout>
     </widget>
    </item>
-   <item>
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
-     </property>
-     <property name="centerButtons">
-      <bool>false</bool>
-     </property>
-    </widget>
-   </item>
   </layout>
  </widget>
  <resources/>
- <connections>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>accepted()</signal>
-   <receiver>MessageOptionsWidget</receiver>
-   <slot>accept()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>248</x>
-     <y>254</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>157</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>rejected()</signal>
-   <receiver>MessageOptionsWidget</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>316</x>
-     <y>260</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>286</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>helpRequested()</signal>
-   <receiver>MessageOptionsWidget</receiver>
-   <slot>helpRequest()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>298</x>
-     <y>204</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>298</x>
-     <y>113</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
  <slots>
   <slot>helpRequest()</slot>
   <slot>textChanged()</slot>
  </slots>
+ <buttongroups>
+  <buttongroup name="groupWindowPos_arg1"/>
+  <buttongroup name="groupWindowType_arg0"/>
+ </buttongroups>
 </ui>

--- a/src/ui/commands/show_message_widget.cpp
+++ b/src/ui/commands/show_message_widget.cpp
@@ -17,18 +17,40 @@
 
 #include "show_message_widget.h"
 #include "ui_show_message_widget.h"
+#include "common/dbstring.h"
+#include "model/event_command_list.h"
+#include "lcf/rpg/eventcommand.h"
 
-ShowMessageWidget::ShowMessageWidget(QWidget *parent, lcf::rpg::EventCommand &command) :
-	QDialog(parent),
-	ui(new Ui::ShowMessageWidget),
-	command(command)
-{
+ShowMessageWidget::ShowMessageWidget(ProjectData &project, QWidget *parent) :
+	EventCommandBaseWidget(project, parent),
+	ui(new Ui::ShowMessageWidget) {
+
 	ui->setupUi(this);
-
-	//TODO
 }
 
-ShowMessageWidget::~ShowMessageWidget()
-{
+ShowMessageWidget::~ShowMessageWidget() {
 	delete ui;
+}
+
+void ShowMessageWidget::setData(EventCommandList* commands) {
+	EventCommandBaseWidget::setData(commands);
+
+	using Cmd = lcf::rpg::EventCommand::Code;
+
+	ui->message->append(ToQString(cmd->string));
+
+	for (size_t i = commands->index() + 1; i < commands->size(); ++i) {
+		auto& cur_cmd = commands->commands()[i];
+
+		if (static_cast<Cmd>(cur_cmd.code) != Cmd::ShowMessage_2) {
+			break;
+		}
+
+		ui->message->append(ToQString(cur_cmd.string));
+	}
+}
+
+void ShowMessageWidget::apply() {
+	//m_commands->command().string = ToDBString(ui->message->toPlainText());
+	// FIXME: Todo
 }

--- a/src/ui/commands/show_message_widget.ui
+++ b/src/ui/commands/show_message_widget.ui
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>ShowMessageWidget</class>
- <widget class="QDialog" name="ShowMessageWidget">
-  <property name="windowModality">
-   <enum>Qt::WindowModal</enum>
-  </property>
+ <widget class="QWidget" name="ShowMessageWidget">
   <property name="geometry">
    <rect>
     <x>0</x>
@@ -16,26 +13,10 @@
   <property name="windowTitle">
    <string>Show message</string>
   </property>
-  <property name="modal">
-   <bool>true</bool>
-  </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QTextEdit" name="text">
+    <widget class="QTextEdit" name="message">
      <property name="acceptRichText">
-      <bool>false</bool>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
-     </property>
-     <property name="centerButtons">
       <bool>false</bool>
      </property>
     </widget>
@@ -45,55 +26,7 @@
  <resources/>
  <connections>
   <connection>
-   <sender>buttonBox</sender>
-   <signal>accepted()</signal>
-   <receiver>ShowMessageWidget</receiver>
-   <slot>accept()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>248</x>
-     <y>254</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>157</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>rejected()</signal>
-   <receiver>ShowMessageWidget</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>316</x>
-     <y>260</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>286</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>helpRequested()</signal>
-   <receiver>ShowMessageWidget</receiver>
-   <slot>helpRequest()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>298</x>
-     <y>204</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>298</x>
-     <y>113</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>text</sender>
+   <sender>message</sender>
    <signal>textChanged()</signal>
    <receiver>ShowMessageWidget</receiver>
    <slot>textChanged()</slot>

--- a/src/ui/commands/show_message_widget.ui
+++ b/src/ui/commands/show_message_widget.ui
@@ -21,6 +21,13 @@
      </property>
     </widget>
    </item>
+   <item>
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>FIXME: Saving not supported yet!</string>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <resources/>

--- a/src/ui/common/operand_widget.cpp
+++ b/src/ui/common/operand_widget.cpp
@@ -17,7 +17,7 @@
 
 #include "operand_widget.h"
 
-void OperandWidgetBase::attach(ProjectData& project, lcf::rpg::EventCommand& cmd, int idx_operand, int idx_value) {
+void OperandWidgetBase::attach(EventCommandBaseWidget&, ProjectData& project, lcf::rpg::EventCommand& cmd, int idx_operand, int idx_value) {
 	m_project = &project;
 	m_cmd = &cmd;
 	m_operation.operand = idx_operand;
@@ -51,19 +51,16 @@ PartyOperandWidget::PartyOperandWidget(QWidget *parent) :
 	gridLayout->addWidget(m_comboVar, 2, 1);
 }
 
-void PartyOperandWidget::attach(ProjectData& project, lcf::rpg::EventCommand& cmd, int idx_operand, int idx_value) {
-	OperandWidgetBase::attach(project, cmd, idx_operand, idx_value);
+void PartyOperandWidget::attach(EventCommandBaseWidget& base_widget, ProjectData& project, lcf::rpg::EventCommand& cmd, int idx_operand, int idx_value) {
+	OperandWidgetBase::attach(base_widget, project, cmd, idx_operand, idx_value);
 
-	LcfWidgetBinding::connect<int32_t>(this, m_buttonGroup);
-	LcfWidgetBinding::bind(m_buttonGroup, *(cmd.parameters.data() + idx_operand));
+	base_widget.connectParameterHandler(m_buttonGroup, idx_operand);
 
 	m_comboValue->makeModel(project);
-	LcfWidgetBinding::connect<int32_t>(this, m_comboValue);
-	LcfWidgetBinding::bind(m_comboValue, *(cmd.parameters.data() + idx_value));
+	base_widget.connectParameterHandler(m_comboValue, idx_value);
 
 	m_comboVar->makeModel(project);
-	LcfWidgetBinding::connect<int32_t>(this, m_comboVar);
-	LcfWidgetBinding::bind(m_comboVar, *(cmd.parameters.data() + idx_value));
+	base_widget.connectParameterHandler(m_comboVar, idx_value);
 }
 
 ValueOperandWidget::ValueOperandWidget(QWidget *parent) :
@@ -88,16 +85,13 @@ ValueOperandWidget::ValueOperandWidget(QWidget *parent) :
 	gridLayout->addWidget(m_comboVar, 1, 1);
 }
 
-void ValueOperandWidget::attach(ProjectData& project, lcf::rpg::EventCommand& cmd, int idx_operand, int idx_value) {
-	OperandWidgetBase::attach(project, cmd, idx_operand, idx_value);
+void ValueOperandWidget::attach(EventCommandBaseWidget& base_widget, ProjectData& project, lcf::rpg::EventCommand& cmd, int idx_operand, int idx_value) {
+	OperandWidgetBase::attach(base_widget, project, cmd, idx_operand, idx_value);
 
-	LcfWidgetBinding::connect<int32_t>(this, m_buttonGroup);
-	LcfWidgetBinding::bind(m_buttonGroup, *(cmd.parameters.data() + idx_operand));
+	base_widget.connectParameterHandler(m_buttonGroup, idx_operand);
 
-	LcfWidgetBinding::connect<int32_t>(this, m_spinValue);
-	LcfWidgetBinding::bind(m_spinValue, *(cmd.parameters.data() + idx_value));
+	base_widget.connectParameterHandler(m_spinValue, idx_value);
 
 	m_comboVar->makeModel(project);
-	LcfWidgetBinding::connect<int32_t>(this, m_comboVar);
-	LcfWidgetBinding::bind(m_comboVar, *(cmd.parameters.data() + idx_value));
+	base_widget.connectParameterHandler(m_comboVar, idx_value);
 }

--- a/src/ui/common/operand_widget.cpp
+++ b/src/ui/common/operand_widget.cpp
@@ -17,11 +17,13 @@
 
 #include "operand_widget.h"
 
-void OperandWidgetBase::attach(EventCommandBaseWidget&, ProjectData& project, lcf::rpg::EventCommand& cmd, int idx_operand, int idx_value) {
+void OperandWidgetBase::attach(EventCommandBaseWidget& base, ProjectData& project, lcf::rpg::EventCommand& cmd, int idx_operand, int idx_value) {
 	m_project = &project;
 	m_cmd = &cmd;
 	m_operation.operand = idx_operand;
 	m_operation.value = idx_value;
+
+	connect(&base, &EventCommandBaseWidget::parameterChanged, this, &OperandWidgetBase::parameterChanged);
 }
 
 PartyOperandWidget::PartyOperandWidget(QWidget *parent) :
@@ -63,6 +65,13 @@ void PartyOperandWidget::attach(EventCommandBaseWidget& base_widget, ProjectData
 	base_widget.connectParameterHandler(m_comboVar, idx_value);
 }
 
+void PartyOperandWidget::parameterChanged(int index, int new_value) {
+	if (index == m_operation.operand) {
+		m_comboValue->setEnabled(new_value == 1);
+		m_comboVar->setEnabled(new_value == 2);
+	}
+}
+
 ValueOperandWidget::ValueOperandWidget(QWidget *parent) :
 	OperandWidgetBase(parent)
 {
@@ -94,4 +103,11 @@ void ValueOperandWidget::attach(EventCommandBaseWidget& base_widget, ProjectData
 
 	m_comboVar->makeModel(project);
 	base_widget.connectParameterHandler(m_comboVar, idx_value);
+}
+
+void ValueOperandWidget::parameterChanged(int index, int new_value) {
+	if (index == m_operation.operand) {
+		m_spinValue->setEnabled(new_value == 0);
+		m_comboVar->setEnabled(new_value == 1);
+	}
 }

--- a/src/ui/common/operand_widget.cpp
+++ b/src/ui/common/operand_widget.cpp
@@ -1,0 +1,103 @@
+/*
+ * This file is part of EasyRPG Editor.
+ *
+ * EasyRPG Editor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Editor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Editor. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "operand_widget.h"
+
+void OperandWidgetBase::attach(ProjectData& project, lcf::rpg::EventCommand& cmd, int idx_operand, int idx_value) {
+	m_project = &project;
+	m_cmd = &cmd;
+	m_operation.operand = idx_operand;
+	m_operation.value = idx_value;
+}
+
+PartyOperandWidget::PartyOperandWidget(QWidget *parent) :
+	OperandWidgetBase(parent)
+{
+	auto* gridLayout = new QGridLayout(this);
+
+	m_radioParty = new QRadioButton(this);
+	m_radioParty->setText("Entiry Party");
+	m_radioValue = new QRadioButton(this);
+	m_radioValue->setText("Specific:");
+	m_radioVar = new QRadioButton(this);
+	m_radioVar->setText("By Variable:");
+	m_buttonGroup = new QButtonGroup(this);
+	m_buttonGroup->addButton(m_radioParty);
+	m_buttonGroup->setId(m_radioParty, 0);
+	m_buttonGroup->addButton(m_radioValue);
+	m_buttonGroup->setId(m_radioValue, 1);
+	m_buttonGroup->addButton(m_radioVar);
+	m_buttonGroup->setId(m_radioVar, 2);
+	m_comboValue = new RpgComboBox<lcf::rpg::Actor>(this);
+	m_comboVar = new VariableRpgComboBox(this);
+	gridLayout->addWidget(m_radioParty, 0, 0);
+	gridLayout->addWidget(m_radioValue, 1, 0);
+	gridLayout->addWidget(m_comboValue, 1, 1);
+	gridLayout->addWidget(m_radioVar, 2, 0);
+	gridLayout->addWidget(m_comboVar, 2, 1);
+}
+
+void PartyOperandWidget::attach(ProjectData& project, lcf::rpg::EventCommand& cmd, int idx_operand, int idx_value) {
+	OperandWidgetBase::attach(project, cmd, idx_operand, idx_value);
+
+	LcfWidgetBinding::connect<int32_t>(this, m_buttonGroup);
+	LcfWidgetBinding::bind(m_buttonGroup, *(cmd.parameters.data() + idx_operand));
+
+	m_comboValue->makeModel(project);
+	LcfWidgetBinding::connect<int32_t>(this, m_comboValue);
+	LcfWidgetBinding::bind(m_comboValue, *(cmd.parameters.data() + idx_value));
+
+	m_comboVar->makeModel(project);
+	LcfWidgetBinding::connect<int32_t>(this, m_comboVar);
+	LcfWidgetBinding::bind(m_comboVar, *(cmd.parameters.data() + idx_value));
+}
+
+ValueOperandWidget::ValueOperandWidget(QWidget *parent) :
+	OperandWidgetBase(parent)
+{
+	auto* gridLayout = new QGridLayout(this);
+
+	m_radioValue = new QRadioButton(this);
+	m_radioValue->setText("Constant:");
+	m_radioVar = new QRadioButton(this);
+	m_radioVar->setText("By Variable:");
+	m_buttonGroup = new QButtonGroup(this);
+	m_buttonGroup->addButton(m_radioValue);
+	m_buttonGroup->setId(m_radioValue, 0);
+	m_buttonGroup->addButton(m_radioVar);
+	m_buttonGroup->setId(m_radioVar, 1);
+	m_spinValue = new QSpinBox(this);
+	m_comboVar = new VariableRpgComboBox(this);
+	gridLayout->addWidget(m_radioValue, 0, 0);
+	gridLayout->addWidget(m_spinValue, 0, 1);
+	gridLayout->addWidget(m_radioVar, 1, 0);
+	gridLayout->addWidget(m_comboVar, 1, 1);
+}
+
+void ValueOperandWidget::attach(ProjectData& project, lcf::rpg::EventCommand& cmd, int idx_operand, int idx_value) {
+	OperandWidgetBase::attach(project, cmd, idx_operand, idx_value);
+
+	LcfWidgetBinding::connect<int32_t>(this, m_buttonGroup);
+	LcfWidgetBinding::bind(m_buttonGroup, *(cmd.parameters.data() + idx_operand));
+
+	LcfWidgetBinding::connect<int32_t>(this, m_spinValue);
+	LcfWidgetBinding::bind(m_spinValue, *(cmd.parameters.data() + idx_value));
+
+	m_comboVar->makeModel(project);
+	LcfWidgetBinding::connect<int32_t>(this, m_comboVar);
+	LcfWidgetBinding::bind(m_comboVar, *(cmd.parameters.data() + idx_value));
+}

--- a/src/ui/common/operand_widget.h
+++ b/src/ui/common/operand_widget.h
@@ -28,20 +28,10 @@ class OperandWidgetBase : public QWidget {
 	Q_OBJECT
 public:
 	explicit OperandWidgetBase(QWidget *parent = nullptr) : QWidget(parent) {}
-/*
-public slots:
-	virtual void indexChanged(int) {};
 
-	void connect(QDialog* diag) {
-		QObject::connect(diag, SIGNAL(valueSelected(int)), this, SLOT(indexChanged(int)));
-	}
-
-protected:
-	QComboBox* m_comboBox;*/
-
-protected:
 	virtual void attach(ProjectData& project, lcf::rpg::EventCommand&, int idx_operand, int idx_value);
 
+protected:
 	ProjectData* m_project = nullptr;
 	lcf::rpg::EventCommand* m_cmd = nullptr;
 

--- a/src/ui/common/operand_widget.h
+++ b/src/ui/common/operand_widget.h
@@ -1,0 +1,151 @@
+/*
+ * This file is part of EasyRPG Editor.
+ *
+ * EasyRPG Editor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Editor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Editor. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "common/lcf_widget_binding.h"
+#include <QWidget>
+#include <QGridLayout>
+#include <QRadioButton>
+#include <QSpinBox>
+#include <QButtonGroup>
+
+class OperandWidgetBase : public QWidget {
+	Q_OBJECT
+public:
+	explicit OperandWidgetBase(QWidget *parent = nullptr) : QWidget(parent) {}
+/*
+public slots:
+	virtual void indexChanged(int) {};
+
+	void connect(QDialog* diag) {
+		QObject::connect(diag, SIGNAL(valueSelected(int)), this, SLOT(indexChanged(int)));
+	}
+
+protected:
+	QComboBox* m_comboBox;*/
+
+protected:
+	virtual void attach(ProjectData& project, lcf::rpg::EventCommand&, int idx_operand, int idx_value);
+
+	ProjectData* m_project = nullptr;
+	lcf::rpg::EventCommand* m_cmd = nullptr;
+
+	struct {
+		int operand = 0;
+		int value = 0;
+	} m_operation;
+};
+
+template <typename LCF>
+class OperandWidget : public OperandWidgetBase
+{
+public:
+	OperandWidget(QWidget *parent);
+
+	void attach(ProjectData& project, lcf::rpg::EventCommand& cmd, int idx_operand, int idx_value) override {
+		OperandWidgetBase::attach(project, cmd, idx_operand, idx_value);
+
+		LcfWidgetBinding::connect<int32_t>(this, m_buttonGroup);
+		LcfWidgetBinding::bind(m_buttonGroup, *(cmd.parameters.data() + idx_operand));
+
+		m_comboValue->makeModel(project);
+		LcfWidgetBinding::connect<int32_t>(this, m_comboValue);
+		LcfWidgetBinding::bind(m_comboValue, *(cmd.parameters.data() + idx_value));
+
+		m_comboVar->makeModel(project);
+		LcfWidgetBinding::connect<int32_t>(this, m_comboVar);
+		LcfWidgetBinding::bind(m_comboVar, *(cmd.parameters.data() + idx_value));
+	}
+
+private:
+	QButtonGroup* m_buttonGroup = nullptr;
+	QRadioButton* m_radioValue = nullptr;
+	QRadioButton* m_radioVar = nullptr;
+	RpgComboBox<LCF>* m_comboValue = nullptr;
+	VariableRpgComboBox* m_comboVar = nullptr;
+};
+
+template <class LCF>
+OperandWidget<LCF>::OperandWidget(QWidget *parent) :
+	OperandWidgetBase(parent)
+{
+	auto* gridLayout = new QGridLayout(this);
+
+	m_radioValue = new QRadioButton(this);
+	m_radioValue->setText("Specific:");
+	m_radioVar = new QRadioButton(this);
+	m_radioVar->setText("By Variable:");
+	m_buttonGroup = new QButtonGroup(this);
+	m_buttonGroup->addButton(m_radioValue);
+	m_buttonGroup->setId(m_radioValue, 0);
+	m_buttonGroup->addButton(m_radioVar);
+	m_buttonGroup->setId(m_radioVar, 1);
+	m_comboValue = new RpgComboBox<LCF>(this);
+	m_comboVar = new VariableRpgComboBox(this);
+	gridLayout->addWidget(m_radioValue, 0, 0);
+	gridLayout->addWidget(m_comboValue, 0, 1);
+	gridLayout->addWidget(m_radioVar, 1, 0);
+	gridLayout->addWidget(m_comboVar, 1, 1);
+}
+
+class PartyOperandWidget : public OperandWidgetBase
+{
+public:
+	PartyOperandWidget(QWidget *parent);
+
+	void attach(ProjectData& project, lcf::rpg::EventCommand& cmd, int idx_operand, int idx_value) override;
+
+private:
+	QButtonGroup* m_buttonGroup = nullptr;
+	QRadioButton* m_radioParty = nullptr;
+	QRadioButton* m_radioValue = nullptr;
+	QRadioButton* m_radioVar = nullptr;
+	RpgComboBox<lcf::rpg::Actor>* m_comboValue = nullptr;
+	VariableRpgComboBox* m_comboVar = nullptr;
+};
+
+class ValueOperandWidget : public OperandWidgetBase
+{
+public:
+	ValueOperandWidget(QWidget *parent);
+
+	void attach(ProjectData& project, lcf::rpg::EventCommand& cmd, int idx_operand, int idx_value) override;
+
+private:
+	QButtonGroup* m_buttonGroup = nullptr;
+	QRadioButton* m_radioValue = nullptr;
+	QRadioButton* m_radioVar = nullptr;
+	QSpinBox* m_spinValue = nullptr;
+	VariableRpgComboBox* m_comboVar = nullptr;
+};
+
+using ActorOperandWidget = OperandWidget<lcf::rpg::Actor>;
+using SkillOperandWidget = OperandWidget<lcf::rpg::Skill>;
+using ItemOperandWidget = OperandWidget<lcf::rpg::Item>;
+using EnemyOperandWidget = OperandWidget<lcf::rpg::Enemy>;
+using TroopOperandWidget = OperandWidget<lcf::rpg::Troop>;
+using TerrainOperandWidget = OperandWidget<lcf::rpg::Terrain>;
+using AttributeOperandWidget = OperandWidget<lcf::rpg::Attribute>;
+using StateOperandWidget = OperandWidget<lcf::rpg::State>;
+using AnimationOperandWidget = OperandWidget<lcf::rpg::Animation>;
+using ChipsetOperandWidget = OperandWidget<lcf::rpg::Chipset>;
+using CommonEventOperandWidget = OperandWidget<lcf::rpg::CommonEvent>;
+using ClassOperandWidget = OperandWidget<lcf::rpg::Class>;
+using BattlerAnimationOperandWidget = OperandWidget<lcf::rpg::BattlerAnimation>;
+using SwitchOperandWidget = OperandWidget<lcf::rpg::Switch>;
+using VariableOperandWidget = OperandWidget<lcf::rpg::Variable>;

--- a/src/ui/common/operand_widget.h
+++ b/src/ui/common/operand_widget.h
@@ -18,18 +18,21 @@
 #pragma once
 
 #include "common/lcf_widget_binding.h"
+#include "ui/event/event_command_base_widget.h"
 #include <QWidget>
 #include <QGridLayout>
 #include <QRadioButton>
 #include <QSpinBox>
 #include <QButtonGroup>
 
+class EventCommandBaseWidget;
+
 class OperandWidgetBase : public QWidget {
 	Q_OBJECT
 public:
 	explicit OperandWidgetBase(QWidget *parent = nullptr) : QWidget(parent) {}
 
-	virtual void attach(ProjectData& project, lcf::rpg::EventCommand&, int idx_operand, int idx_value);
+	virtual void attach(EventCommandBaseWidget& base_widget, ProjectData& project, lcf::rpg::EventCommand&, int idx_operand, int idx_value);
 
 protected:
 	ProjectData* m_project = nullptr;
@@ -47,19 +50,16 @@ class OperandWidget : public OperandWidgetBase
 public:
 	OperandWidget(QWidget *parent);
 
-	void attach(ProjectData& project, lcf::rpg::EventCommand& cmd, int idx_operand, int idx_value) override {
-		OperandWidgetBase::attach(project, cmd, idx_operand, idx_value);
+	void attach(EventCommandBaseWidget& base_widget, ProjectData& project, lcf::rpg::EventCommand& cmd, int idx_operand, int idx_value) override {
+		OperandWidgetBase::attach(base_widget, project, cmd, idx_operand, idx_value);
 
-		LcfWidgetBinding::connect<int32_t>(this, m_buttonGroup);
-		LcfWidgetBinding::bind(m_buttonGroup, *(cmd.parameters.data() + idx_operand));
+		base_widget.connectParameterHandler(m_buttonGroup, idx_operand);
 
 		m_comboValue->makeModel(project);
-		LcfWidgetBinding::connect<int32_t>(this, m_comboValue);
-		LcfWidgetBinding::bind(m_comboValue, *(cmd.parameters.data() + idx_value));
+		base_widget.connectParameterHandler(m_comboValue, idx_value);
 
 		m_comboVar->makeModel(project);
-		LcfWidgetBinding::connect<int32_t>(this, m_comboVar);
-		LcfWidgetBinding::bind(m_comboVar, *(cmd.parameters.data() + idx_value));
+		base_widget.connectParameterHandler(m_comboVar, idx_value);
 	}
 
 private:
@@ -98,7 +98,7 @@ class PartyOperandWidget : public OperandWidgetBase
 public:
 	PartyOperandWidget(QWidget *parent);
 
-	void attach(ProjectData& project, lcf::rpg::EventCommand& cmd, int idx_operand, int idx_value) override;
+	void attach(EventCommandBaseWidget& base_widget, ProjectData& project, lcf::rpg::EventCommand& cmd, int idx_operand, int idx_value) override;
 
 private:
 	QButtonGroup* m_buttonGroup = nullptr;
@@ -114,7 +114,7 @@ class ValueOperandWidget : public OperandWidgetBase
 public:
 	ValueOperandWidget(QWidget *parent);
 
-	void attach(ProjectData& project, lcf::rpg::EventCommand& cmd, int idx_operand, int idx_value) override;
+	void attach(EventCommandBaseWidget& base_widget, ProjectData& project, lcf::rpg::EventCommand& cmd, int idx_operand, int idx_value) override;
 
 private:
 	QButtonGroup* m_buttonGroup = nullptr;

--- a/src/ui/common/operand_widget.h
+++ b/src/ui/common/operand_widget.h
@@ -35,6 +35,11 @@ public:
 	virtual void attach(EventCommandBaseWidget& base_widget, ProjectData& project, lcf::rpg::EventCommand&, int idx_operand, int idx_value);
 
 protected:
+	virtual void parameterChanged(int index, int new_value) {
+		Q_UNUSED(index);
+		Q_UNUSED(new_value);
+	}
+
 	ProjectData* m_project = nullptr;
 	lcf::rpg::EventCommand* m_cmd = nullptr;
 
@@ -45,8 +50,7 @@ protected:
 };
 
 template <typename LCF>
-class OperandWidget : public OperandWidgetBase
-{
+class OperandWidget : public OperandWidgetBase {
 public:
 	OperandWidget(QWidget *parent);
 
@@ -60,6 +64,13 @@ public:
 
 		m_comboVar->makeModel(project);
 		base_widget.connectParameterHandler(m_comboVar, idx_value);
+	}
+
+	void parameterChanged(int index, int new_value) override {
+		if (index == m_operation.operand) {
+			m_comboValue->setEnabled(new_value == 0);
+			m_comboVar->setEnabled(new_value == 1);
+		}
 	}
 
 private:
@@ -93,12 +104,14 @@ OperandWidget<LCF>::OperandWidget(QWidget *parent) :
 	gridLayout->addWidget(m_comboVar, 1, 1);
 }
 
-class PartyOperandWidget : public OperandWidgetBase
-{
+class PartyOperandWidget : public OperandWidgetBase {
 public:
 	PartyOperandWidget(QWidget *parent);
 
 	void attach(EventCommandBaseWidget& base_widget, ProjectData& project, lcf::rpg::EventCommand& cmd, int idx_operand, int idx_value) override;
+
+protected:
+	void parameterChanged(int index, int new_value) override;
 
 private:
 	QButtonGroup* m_buttonGroup = nullptr;
@@ -109,12 +122,14 @@ private:
 	VariableRpgComboBox* m_comboVar = nullptr;
 };
 
-class ValueOperandWidget : public OperandWidgetBase
-{
+class ValueOperandWidget : public OperandWidgetBase {
 public:
 	ValueOperandWidget(QWidget *parent);
 
 	void attach(EventCommandBaseWidget& base_widget, ProjectData& project, lcf::rpg::EventCommand& cmd, int idx_operand, int idx_value) override;
+
+protected:
+	void parameterChanged(int index, int new_value) override;
 
 private:
 	QButtonGroup* m_buttonGroup = nullptr;

--- a/src/ui/common/rpg_combobox.h
+++ b/src/ui/common/rpg_combobox.h
@@ -38,12 +38,19 @@ class RpgComboBoxBase : public QWidget {
 public:
 	explicit RpgComboBoxBase(QWidget *parent = nullptr) : QWidget(parent) {}
 
+	QComboBox* comboBox() {
+		return m_comboBox;
+	}
+
 public slots:
 	virtual void indexChanged(int) {};
 
 	void connect(QDialog* diag) {
 		QObject::connect(diag, SIGNAL(valueSelected(int)), this, SLOT(indexChanged(int)));
 	}
+
+protected:
+	QComboBox* m_comboBox;
 };
 
 template <typename LCF>
@@ -51,10 +58,6 @@ class RpgComboBox : public RpgComboBoxBase
 {
 public:
 	RpgComboBox(QWidget *parent, QAbstractItemModel *model = nullptr);
-
-	QComboBox* comboBox() {
-		return m_comboBox;
-	}
 
 	// The member "setEditable" is missing on purpose. Don't set it in the UI!
 
@@ -101,7 +104,6 @@ public:
 	};
 
 private:
-	QComboBox* m_comboBox;
 	QPushButton* m_editButton;
 	ProjectData* m_project = nullptr;
 	RpgModel<LCF>* m_model = nullptr;

--- a/src/ui/common/widget_as_dialog_wrapper.h
+++ b/src/ui/common/widget_as_dialog_wrapper.h
@@ -90,6 +90,17 @@ protected:
 	QDialogButtonBox* buttonBox = nullptr;
 };
 
+template <typename T>
+class HasApply {
+private:
+	typedef char YesType[1];
+	typedef char NoType[2];
+	template <typename C> static YesType& test( decltype(&C::apply) ) ;
+	template <typename C> static NoType& test(...);
+public:
+	enum { value = sizeof(test<T>(0)) == sizeof(YesType) };
+};
+
 /**
  * Wraps a Widget inside a Dialog and applies the forwarded data when OK or Apply
  * are pressed
@@ -118,6 +129,10 @@ public:
 
 private:
 	void apply() override {
+		if constexpr (HasApply<WIDGET>::value) {
+			wrappedWidget->apply();
+		}
+
 		dataOriginal = dataCopy;
 	}
 

--- a/src/ui/database/actor_widget.cpp
+++ b/src/ui/database/actor_widget.cpp
@@ -121,7 +121,7 @@ ActorWidget::ActorWidget(ProjectData& project, QWidget *parent) :
 			ui->checkFixedEquip,
 			ui->checkStrongDefense,
 			ui->checkTranslucent }) {
-		LcfWidgetBinding::connect(this, uis);
+		LcfWidgetBinding::connect<bool>(this, uis);
 	}
 
 	for (auto& uis : {
@@ -141,7 +141,7 @@ ActorWidget::ActorWidget(ProjectData& project, QWidget *parent) :
 		uis->makeModel(project);
 	}
 
-	LcfWidgetBinding::connect(this, ui->groupCritChance);
+	LcfWidgetBinding::connect<bool>(this, ui->groupCritChance);
 
 	LcfWidgetBinding::connect<int32_t>(this, ui->comboUnarmedAnimation);
 	ui->comboUnarmedAnimation->makeModel(project);

--- a/src/ui/database/attribute_widget.ui
+++ b/src/ui/database/attribute_widget.ui
@@ -13,626 +13,172 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <widget class="QLineEdit" name="lineOld_CharacterFilter_6">
-   <property name="geometry">
-    <rect>
-     <x>10</x>
-     <y>40</y>
-     <width>150</width>
-     <height>20</height>
-    </rect>
-   </property>
-   <property name="placeholderText">
-    <string>Filter</string>
-   </property>
-  </widget>
-  <widget class="QListWidget" name="listOld_Character_6">
-   <property name="geometry">
-    <rect>
-     <x>10</x>
-     <y>60</y>
-     <width>150</width>
-     <height>465</height>
-    </rect>
-   </property>
-   <property name="maximumSize">
-    <size>
-     <width>150</width>
-     <height>16777215</height>
-    </size>
-   </property>
-   <property name="selectionRectVisible">
-    <bool>true</bool>
-   </property>
-  </widget>
-  <widget class="QFrame" name="frame_6">
-   <property name="geometry">
-    <rect>
-     <x>170</x>
-     <y>10</y>
-     <width>581</width>
-     <height>541</height>
-    </rect>
-   </property>
-   <property name="sizePolicy">
-    <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-     <horstretch>1</horstretch>
-     <verstretch>0</verstretch>
-    </sizepolicy>
-   </property>
-   <property name="frameShape">
-    <enum>QFrame::WinPanel</enum>
-   </property>
-   <property name="frameShadow">
-    <enum>QFrame::Sunken</enum>
-   </property>
-   <widget class="QGroupBox" name="groupBox_50">
-    <property name="geometry">
-     <rect>
-      <x>10</x>
-      <y>10</y>
-      <width>151</width>
-      <height>51</height>
-     </rect>
-    </property>
-    <property name="title">
-     <string>Name</string>
-    </property>
-    <widget class="QLineEdit" name="lineEdit_7">
-     <property name="geometry">
-      <rect>
-       <x>10</x>
-       <y>20</y>
-       <width>113</width>
+  <layout class="QGridLayout" name="gridLayout_2">
+   <item row="0" column="0">
+    <layout class="QVBoxLayout" name="verticalLayout">
+     <item>
+      <layout class="QFormLayout" name="formLayout_2">
+       <item row="0" column="0">
+        <widget class="QLabel" name="label">
+         <property name="text">
+          <string>Name:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QLineEdit" name="lineName"/>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <widget class="QGroupBox" name="groupBox_55">
+       <property name="title">
+        <string>Attribute Type</string>
+       </property>
+       <layout class="QGridLayout" name="gridLayout">
+        <item row="0" column="0">
+         <widget class="QRadioButton" name="radioWeapon">
+          <property name="text">
+           <string>Weapon</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QRadioButton" name="radioMagic">
+          <property name="text">
+           <string>Magic</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item>
+      <widget class="QGroupBox" name="groupBox_56">
+       <property name="title">
+        <string>Damage Multiplier</string>
+       </property>
+       <layout class="QFormLayout" name="formLayout">
+        <item row="0" column="0">
+         <widget class="QLabel" name="label_2">
+          <property name="text">
+           <string>A:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QSpinBox" name="spinA">
+          <property name="suffix">
+           <string> %</string>
+          </property>
+          <property name="maximum">
+           <number>99999</number>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="label_3">
+          <property name="text">
+           <string>B:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QSpinBox" name="spinB">
+          <property name="suffix">
+           <string> %</string>
+          </property>
+          <property name="maximum">
+           <number>99999</number>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="label_4">
+          <property name="text">
+           <string>C:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="QSpinBox" name="spinC">
+          <property name="suffix">
+           <string> %</string>
+          </property>
+          <property name="maximum">
+           <number>99999</number>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="0">
+         <widget class="QLabel" name="label_5">
+          <property name="text">
+           <string>D:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="1">
+         <widget class="QSpinBox" name="spinD">
+          <property name="suffix">
+           <string> %</string>
+          </property>
+          <property name="maximum">
+           <number>99999</number>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="0">
+         <widget class="QLabel" name="label_6">
+          <property name="text">
+           <string>E:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="1">
+         <widget class="QSpinBox" name="spinE">
+          <property name="suffix">
+           <string> %</string>
+          </property>
+          <property name="minimum">
+           <number>-99999</number>
+          </property>
+          <property name="maximum">
+           <number>99999</number>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item>
+      <spacer name="verticalSpacer">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>40</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item row="0" column="1">
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>367</width>
        <height>20</height>
-      </rect>
+      </size>
      </property>
-    </widget>
-   </widget>
-   <widget class="QGroupBox" name="groupBox_55">
-    <property name="geometry">
-     <rect>
-      <x>10</x>
-      <y>70</y>
-      <width>151</width>
-      <height>101</height>
-     </rect>
-    </property>
-    <property name="title">
-     <string>Attribute Type</string>
-    </property>
-    <widget class="QRadioButton" name="radioButton_7">
-     <property name="geometry">
-      <rect>
-       <x>30</x>
-       <y>30</y>
-       <width>82</width>
-       <height>17</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>Weapon</string>
-     </property>
-    </widget>
-    <widget class="QRadioButton" name="radioButton_8">
-     <property name="geometry">
-      <rect>
-       <x>30</x>
-       <y>60</y>
-       <width>82</width>
-       <height>17</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>Magic</string>
-     </property>
-    </widget>
-   </widget>
-   <widget class="QGroupBox" name="groupBox_56">
-    <property name="geometry">
-     <rect>
-      <x>10</x>
-      <y>190</y>
-      <width>151</width>
-      <height>211</height>
-     </rect>
-    </property>
-    <property name="title">
-     <string>Damage Multiplayer</string>
-    </property>
-    <widget class="QSpinBox" name="spinBox_5">
-     <property name="geometry">
-      <rect>
-       <x>41</x>
-       <y>40</y>
-       <width>51</width>
-       <height>22</height>
-      </rect>
-     </property>
-    </widget>
-    <widget class="QSpinBox" name="spinBox_6">
-     <property name="geometry">
-      <rect>
-       <x>40</x>
-       <y>70</y>
-       <width>51</width>
-       <height>22</height>
-      </rect>
-     </property>
-    </widget>
-    <widget class="QSpinBox" name="spinBox_7">
-     <property name="geometry">
-      <rect>
-       <x>40</x>
-       <y>100</y>
-       <width>51</width>
-       <height>22</height>
-      </rect>
-     </property>
-    </widget>
-    <widget class="QSpinBox" name="spinBox_8">
-     <property name="geometry">
-      <rect>
-       <x>40</x>
-       <y>130</y>
-       <width>51</width>
-       <height>22</height>
-      </rect>
-     </property>
-    </widget>
-    <widget class="QSpinBox" name="spinBox_9">
-     <property name="geometry">
-      <rect>
-       <x>40</x>
-       <y>160</y>
-       <width>51</width>
-       <height>22</height>
-      </rect>
-     </property>
-    </widget>
-   </widget>
-  </widget>
-  <widget class="QLabel" name="label_26">
-   <property name="geometry">
-    <rect>
-     <x>10</x>
-     <y>10</y>
-     <width>151</width>
-     <height>23</height>
-    </rect>
-   </property>
-   <property name="palette">
-    <palette>
-     <active>
-      <colorrole role="WindowText">
-       <brush brushstyle="SolidPattern">
-        <color alpha="255">
-         <red>255</red>
-         <green>255</green>
-         <blue>255</blue>
-        </color>
-       </brush>
-      </colorrole>
-      <colorrole role="Button">
-       <brush brushstyle="SolidPattern">
-        <color alpha="255">
-         <red>0</red>
-         <green>0</green>
-         <blue>0</blue>
-        </color>
-       </brush>
-      </colorrole>
-      <colorrole role="Light">
-       <brush brushstyle="SolidPattern">
-        <color alpha="255">
-         <red>0</red>
-         <green>0</green>
-         <blue>0</blue>
-        </color>
-       </brush>
-      </colorrole>
-      <colorrole role="Midlight">
-       <brush brushstyle="SolidPattern">
-        <color alpha="255">
-         <red>0</red>
-         <green>0</green>
-         <blue>0</blue>
-        </color>
-       </brush>
-      </colorrole>
-      <colorrole role="Dark">
-       <brush brushstyle="SolidPattern">
-        <color alpha="255">
-         <red>0</red>
-         <green>0</green>
-         <blue>0</blue>
-        </color>
-       </brush>
-      </colorrole>
-      <colorrole role="Mid">
-       <brush brushstyle="SolidPattern">
-        <color alpha="255">
-         <red>0</red>
-         <green>0</green>
-         <blue>0</blue>
-        </color>
-       </brush>
-      </colorrole>
-      <colorrole role="Text">
-       <brush brushstyle="SolidPattern">
-        <color alpha="255">
-         <red>255</red>
-         <green>255</green>
-         <blue>255</blue>
-        </color>
-       </brush>
-      </colorrole>
-      <colorrole role="BrightText">
-       <brush brushstyle="SolidPattern">
-        <color alpha="255">
-         <red>255</red>
-         <green>255</green>
-         <blue>255</blue>
-        </color>
-       </brush>
-      </colorrole>
-      <colorrole role="ButtonText">
-       <brush brushstyle="SolidPattern">
-        <color alpha="255">
-         <red>255</red>
-         <green>255</green>
-         <blue>255</blue>
-        </color>
-       </brush>
-      </colorrole>
-      <colorrole role="Base">
-       <brush brushstyle="SolidPattern">
-        <color alpha="255">
-         <red>0</red>
-         <green>0</green>
-         <blue>0</blue>
-        </color>
-       </brush>
-      </colorrole>
-      <colorrole role="Window">
-       <brush brushstyle="SolidPattern">
-        <color alpha="255">
-         <red>0</red>
-         <green>0</green>
-         <blue>0</blue>
-        </color>
-       </brush>
-      </colorrole>
-      <colorrole role="Shadow">
-       <brush brushstyle="SolidPattern">
-        <color alpha="255">
-         <red>0</red>
-         <green>0</green>
-         <blue>0</blue>
-        </color>
-       </brush>
-      </colorrole>
-      <colorrole role="AlternateBase">
-       <brush brushstyle="SolidPattern">
-        <color alpha="255">
-         <red>0</red>
-         <green>0</green>
-         <blue>0</blue>
-        </color>
-       </brush>
-      </colorrole>
-      <colorrole role="ToolTipBase">
-       <brush brushstyle="SolidPattern">
-        <color alpha="255">
-         <red>255</red>
-         <green>255</green>
-         <blue>220</blue>
-        </color>
-       </brush>
-      </colorrole>
-      <colorrole role="ToolTipText">
-       <brush brushstyle="SolidPattern">
-        <color alpha="255">
-         <red>0</red>
-         <green>0</green>
-         <blue>0</blue>
-        </color>
-       </brush>
-      </colorrole>
-     </active>
-     <inactive>
-      <colorrole role="WindowText">
-       <brush brushstyle="SolidPattern">
-        <color alpha="255">
-         <red>255</red>
-         <green>255</green>
-         <blue>255</blue>
-        </color>
-       </brush>
-      </colorrole>
-      <colorrole role="Button">
-       <brush brushstyle="SolidPattern">
-        <color alpha="255">
-         <red>0</red>
-         <green>0</green>
-         <blue>0</blue>
-        </color>
-       </brush>
-      </colorrole>
-      <colorrole role="Light">
-       <brush brushstyle="SolidPattern">
-        <color alpha="255">
-         <red>0</red>
-         <green>0</green>
-         <blue>0</blue>
-        </color>
-       </brush>
-      </colorrole>
-      <colorrole role="Midlight">
-       <brush brushstyle="SolidPattern">
-        <color alpha="255">
-         <red>0</red>
-         <green>0</green>
-         <blue>0</blue>
-        </color>
-       </brush>
-      </colorrole>
-      <colorrole role="Dark">
-       <brush brushstyle="SolidPattern">
-        <color alpha="255">
-         <red>0</red>
-         <green>0</green>
-         <blue>0</blue>
-        </color>
-       </brush>
-      </colorrole>
-      <colorrole role="Mid">
-       <brush brushstyle="SolidPattern">
-        <color alpha="255">
-         <red>0</red>
-         <green>0</green>
-         <blue>0</blue>
-        </color>
-       </brush>
-      </colorrole>
-      <colorrole role="Text">
-       <brush brushstyle="SolidPattern">
-        <color alpha="255">
-         <red>255</red>
-         <green>255</green>
-         <blue>255</blue>
-        </color>
-       </brush>
-      </colorrole>
-      <colorrole role="BrightText">
-       <brush brushstyle="SolidPattern">
-        <color alpha="255">
-         <red>255</red>
-         <green>255</green>
-         <blue>255</blue>
-        </color>
-       </brush>
-      </colorrole>
-      <colorrole role="ButtonText">
-       <brush brushstyle="SolidPattern">
-        <color alpha="255">
-         <red>255</red>
-         <green>255</green>
-         <blue>255</blue>
-        </color>
-       </brush>
-      </colorrole>
-      <colorrole role="Base">
-       <brush brushstyle="SolidPattern">
-        <color alpha="255">
-         <red>0</red>
-         <green>0</green>
-         <blue>0</blue>
-        </color>
-       </brush>
-      </colorrole>
-      <colorrole role="Window">
-       <brush brushstyle="SolidPattern">
-        <color alpha="255">
-         <red>0</red>
-         <green>0</green>
-         <blue>0</blue>
-        </color>
-       </brush>
-      </colorrole>
-      <colorrole role="Shadow">
-       <brush brushstyle="SolidPattern">
-        <color alpha="255">
-         <red>0</red>
-         <green>0</green>
-         <blue>0</blue>
-        </color>
-       </brush>
-      </colorrole>
-      <colorrole role="AlternateBase">
-       <brush brushstyle="SolidPattern">
-        <color alpha="255">
-         <red>0</red>
-         <green>0</green>
-         <blue>0</blue>
-        </color>
-       </brush>
-      </colorrole>
-      <colorrole role="ToolTipBase">
-       <brush brushstyle="SolidPattern">
-        <color alpha="255">
-         <red>255</red>
-         <green>255</green>
-         <blue>220</blue>
-        </color>
-       </brush>
-      </colorrole>
-      <colorrole role="ToolTipText">
-       <brush brushstyle="SolidPattern">
-        <color alpha="255">
-         <red>0</red>
-         <green>0</green>
-         <blue>0</blue>
-        </color>
-       </brush>
-      </colorrole>
-     </inactive>
-     <disabled>
-      <colorrole role="WindowText">
-       <brush brushstyle="SolidPattern">
-        <color alpha="255">
-         <red>0</red>
-         <green>0</green>
-         <blue>0</blue>
-        </color>
-       </brush>
-      </colorrole>
-      <colorrole role="Button">
-       <brush brushstyle="SolidPattern">
-        <color alpha="255">
-         <red>0</red>
-         <green>0</green>
-         <blue>0</blue>
-        </color>
-       </brush>
-      </colorrole>
-      <colorrole role="Light">
-       <brush brushstyle="SolidPattern">
-        <color alpha="255">
-         <red>0</red>
-         <green>0</green>
-         <blue>0</blue>
-        </color>
-       </brush>
-      </colorrole>
-      <colorrole role="Midlight">
-       <brush brushstyle="SolidPattern">
-        <color alpha="255">
-         <red>0</red>
-         <green>0</green>
-         <blue>0</blue>
-        </color>
-       </brush>
-      </colorrole>
-      <colorrole role="Dark">
-       <brush brushstyle="SolidPattern">
-        <color alpha="255">
-         <red>0</red>
-         <green>0</green>
-         <blue>0</blue>
-        </color>
-       </brush>
-      </colorrole>
-      <colorrole role="Mid">
-       <brush brushstyle="SolidPattern">
-        <color alpha="255">
-         <red>0</red>
-         <green>0</green>
-         <blue>0</blue>
-        </color>
-       </brush>
-      </colorrole>
-      <colorrole role="Text">
-       <brush brushstyle="SolidPattern">
-        <color alpha="255">
-         <red>0</red>
-         <green>0</green>
-         <blue>0</blue>
-        </color>
-       </brush>
-      </colorrole>
-      <colorrole role="BrightText">
-       <brush brushstyle="SolidPattern">
-        <color alpha="255">
-         <red>255</red>
-         <green>255</green>
-         <blue>255</blue>
-        </color>
-       </brush>
-      </colorrole>
-      <colorrole role="ButtonText">
-       <brush brushstyle="SolidPattern">
-        <color alpha="255">
-         <red>0</red>
-         <green>0</green>
-         <blue>0</blue>
-        </color>
-       </brush>
-      </colorrole>
-      <colorrole role="Base">
-       <brush brushstyle="SolidPattern">
-        <color alpha="255">
-         <red>0</red>
-         <green>0</green>
-         <blue>0</blue>
-        </color>
-       </brush>
-      </colorrole>
-      <colorrole role="Window">
-       <brush brushstyle="SolidPattern">
-        <color alpha="255">
-         <red>0</red>
-         <green>0</green>
-         <blue>0</blue>
-        </color>
-       </brush>
-      </colorrole>
-      <colorrole role="Shadow">
-       <brush brushstyle="SolidPattern">
-        <color alpha="255">
-         <red>0</red>
-         <green>0</green>
-         <blue>0</blue>
-        </color>
-       </brush>
-      </colorrole>
-      <colorrole role="AlternateBase">
-       <brush brushstyle="SolidPattern">
-        <color alpha="255">
-         <red>0</red>
-         <green>0</green>
-         <blue>0</blue>
-        </color>
-       </brush>
-      </colorrole>
-      <colorrole role="ToolTipBase">
-       <brush brushstyle="SolidPattern">
-        <color alpha="255">
-         <red>255</red>
-         <green>255</green>
-         <blue>220</blue>
-        </color>
-       </brush>
-      </colorrole>
-      <colorrole role="ToolTipText">
-       <brush brushstyle="SolidPattern">
-        <color alpha="255">
-         <red>0</red>
-         <green>0</green>
-         <blue>0</blue>
-        </color>
-       </brush>
-      </colorrole>
-     </disabled>
-    </palette>
-   </property>
-   <property name="font">
-    <font>
-     <pointsize>10</pointsize>
-     <weight>75</weight>
-     <bold>true</bold>
-    </font>
-   </property>
-   <property name="autoFillBackground">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Attributes</string>
-   </property>
-   <property name="alignment">
-    <set>Qt::AlignCenter</set>
-   </property>
-  </widget>
+    </spacer>
+   </item>
+  </layout>
  </widget>
  <resources/>
  <connections/>

--- a/src/ui/database/common_event_widget.cpp
+++ b/src/ui/database/common_event_widget.cpp
@@ -28,7 +28,7 @@ CommonEventWidget::CommonEventWidget(ProjectData& project, QWidget *parent) :
 
 	LcfWidgetBinding::connect(this, ui->lineName);
 	LcfWidgetBinding::connect<int32_t>(this, ui->comboTrigger);
-	LcfWidgetBinding::connect(this, ui->groupSwitch);
+	LcfWidgetBinding::connect<bool>(this, ui->groupSwitch);
 	ui->comboSwitch->makeModel(project);
 }
 

--- a/src/ui/event/event_command_base_widget.cpp
+++ b/src/ui/event/event_command_base_widget.cpp
@@ -18,6 +18,7 @@
 #include "event_command_base_widget.h"
 #include "common/lcf_widget_binding.h"
 #include "ui/common/operand_widget.h"
+#include "model/event_command_list.h"
 #include <QLineEdit>
 #include <QButtonGroup>
 
@@ -111,6 +112,11 @@ void EventCommandBaseWidget::setData(lcf::rpg::EventCommand* cmd) {
 			}
 		}
 	}
+}
+
+void EventCommandBaseWidget::setData(EventCommandList* commands) {
+	m_commands = commands;
+	setData(&commands->command());
 }
 
 void EventCommandBaseWidget::connectParameterHandler(QButtonGroup* group, int index) {

--- a/src/ui/event/event_command_base_widget.cpp
+++ b/src/ui/event/event_command_base_widget.cpp
@@ -28,8 +28,6 @@ EventCommandBaseWidget::EventCommandBaseWidget(ProjectData& project, QWidget* pa
 void EventCommandBaseWidget::setData(lcf::rpg::EventCommand* cmd) {
 	this->cmd = cmd;
 
-	dumpObjectTree();
-
 	for (auto& widget: findChildren<QLineEdit*>()) {
 		auto idx = widget->objectName().indexOf("_argX");
 		if (idx != -1) {

--- a/src/ui/event/event_command_base_widget.cpp
+++ b/src/ui/event/event_command_base_widget.cpp
@@ -16,7 +16,8 @@
  */
 
 #include "event_command_base_widget.h"
-#include <common/lcf_widget_binding.h>
+#include "common/lcf_widget_binding.h"
+#include "ui/common/operand_widget.h"
 #include <QLineEdit>
 #include <QButtonGroup>
 
@@ -92,6 +93,20 @@ void EventCommandBaseWidget::setData(lcf::rpg::EventCommand* cmd) {
 			} else {
 				LcfWidgetBinding::connect<int32_t>(this, widget);
 				LcfWidgetBinding::bind(widget, *(cmd->parameters.data() + val));
+			}
+		}
+	}
+
+	for (auto& widget: findChildren<OperandWidgetBase*>()) {
+		auto idx = widget->objectName().indexOf("_arg");
+		if (idx != -1) {
+			QString arg = widget->objectName().right(1);
+			int val = arg.toInt(nullptr, 10);
+
+			if (arg == "X") {
+				Q_ASSERT(false && "QComboBox does not support string arg");
+			} else {
+				widget->attach(m_project, *cmd, val, val + 1);
 			}
 		}
 	}

--- a/src/ui/event/event_command_base_widget.cpp
+++ b/src/ui/event/event_command_base_widget.cpp
@@ -1,0 +1,100 @@
+/*
+ * This file is part of EasyRPG Editor.
+ *
+ * EasyRPG Editor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Editor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Editor. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "event_command_base_widget.h"
+#include <common/lcf_widget_binding.h>
+#include <QLineEdit>
+#include <QButtonGroup>
+
+EventCommandBaseWidget::EventCommandBaseWidget(ProjectData& project, QWidget* parent) :
+	QWidget(parent), m_project(project) {
+
+}
+
+void EventCommandBaseWidget::setData(lcf::rpg::EventCommand* cmd) {
+	this->cmd = cmd;
+
+	dumpObjectTree();
+
+	for (auto& widget: findChildren<QLineEdit*>()) {
+		auto idx = widget->objectName().indexOf("_argX");
+		if (idx != -1) {
+			LcfWidgetBinding::connect(this, widget);
+			LcfWidgetBinding::bind(widget, cmd->string);
+		}
+	}
+
+	for (auto& widget: findChildren<QSpinBox*>()) {
+		auto idx = widget->objectName().indexOf("_arg");
+		if (idx != -1) {
+			QString arg = widget->objectName().right(1);
+			int val = arg.toInt(nullptr, 10);
+
+			if (arg == "X") {
+				Q_ASSERT(false && "QSpinBox does not support string arg");
+			} else {
+				LcfWidgetBinding::connect<int32_t>(this, widget);
+				LcfWidgetBinding::bind(widget, *(cmd->parameters.data() + val));
+			}
+		}
+	}
+
+	for (auto& widget: findChildren<QCheckBox*>()) {
+		auto idx = widget->objectName().indexOf("_arg");
+		if (idx != -1) {
+			QString arg = widget->objectName().right(1);
+			int val = arg.toInt(nullptr, 10);
+
+			if (arg == "X") {
+				Q_ASSERT(false && "QCheckBox does not support string arg");
+			} else {
+				LcfWidgetBinding::connect<int32_t>(this, widget);
+				LcfWidgetBinding::bind(widget, *(cmd->parameters.data() + val));
+			}
+		}
+	}
+
+	for (auto& widget: findChildren<RpgComboBoxBase*>()) {
+		auto idx = widget->objectName().indexOf("_arg");
+		if (idx != -1) {
+			QString arg = widget->objectName().right(1);
+			int val = arg.toInt(nullptr, 10);
+
+			if (arg == "X") {
+				Q_ASSERT(false && "QComboBox does not support string arg");
+			} else {
+				LcfWidgetBinding::connect<int32_t>(this, widget->comboBox());
+				LcfWidgetBinding::bind(widget->comboBox(), *(cmd->parameters.data() + val));
+			}
+		}
+	}
+
+	for (auto& widget: findChildren<QButtonGroup*>()) {
+		auto idx = widget->objectName().indexOf("_arg");
+		if (idx != -1) {
+			QString arg = widget->objectName().right(1);
+			int val = arg.toInt(nullptr, 10);
+
+			if (arg == "X") {
+				Q_ASSERT(false && "QComboBox does not support string arg");
+			} else {
+				LcfWidgetBinding::connect<int32_t>(this, widget);
+				LcfWidgetBinding::bind(widget, *(cmd->parameters.data() + val));
+			}
+		}
+	}
+}

--- a/src/ui/event/event_command_base_widget.h
+++ b/src/ui/event/event_command_base_widget.h
@@ -27,6 +27,7 @@ class QCheckBox;
 class QSpinBox;
 class ProjectData;
 class RpgComboBoxBase;
+class EventCommandList;
 
 class EventCommandBaseWidget : public QWidget
 {
@@ -35,6 +36,7 @@ public:
 	EventCommandBaseWidget(ProjectData& project, QWidget* parent);
 
 	virtual void setData(lcf::rpg::EventCommand* cmd);
+	virtual void setData(EventCommandList* commands);
 
 	void connectParameterHandler(QButtonGroup* group, int index);
 	void connectParameterHandler(RpgComboBoxBase* combo, int index);
@@ -47,5 +49,6 @@ signals:
 
 protected:
 	ProjectData& m_project;
+	EventCommandList* m_commands = nullptr;
 	lcf::rpg::EventCommand* cmd = nullptr;
 };

--- a/src/ui/event/event_command_base_widget.h
+++ b/src/ui/event/event_command_base_widget.h
@@ -15,30 +15,25 @@
  * along with EasyRPG Editor. If not, see <http://www.gnu.org/licenses/>.
  */
 
+
 #pragma once
 
 #include <QWidget>
+#include <lcf/rpg/eventcommand.h>
+#include <lcf/rpg/database.h>
 
-class SignalBlocker {
+
+class ProjectData;
+
+class EventCommandBaseWidget : public QWidget
+{
+	Q_OBJECT
 public:
-	SignalBlocker(QObject* item) {
-		items = {item};
-		item->blockSignals(true);
-	}
+	EventCommandBaseWidget(ProjectData& project, QWidget* parent);
 
-	SignalBlocker(std::initializer_list<QObject*> items) {
-		for (auto& item : items) {
-			item->blockSignals(true);
-		}
-		this->items = items;
-	}
+	void setData(lcf::rpg::EventCommand* cmd);
 
-	~SignalBlocker() {
-		for (auto& item : items) {
-			item->blockSignals(false);
-		}
-	}
-
-private:
-	std::vector<QObject*> items;
+protected:
+	ProjectData& m_project;
+	lcf::rpg::EventCommand* cmd = nullptr;
 };

--- a/src/ui/event/event_command_base_widget.h
+++ b/src/ui/event/event_command_base_widget.h
@@ -22,8 +22,11 @@
 #include <lcf/rpg/eventcommand.h>
 #include <lcf/rpg/database.h>
 
-
+class QButtonGroup;
+class QCheckBox;
+class QSpinBox;
 class ProjectData;
+class RpgComboBoxBase;
 
 class EventCommandBaseWidget : public QWidget
 {
@@ -32,6 +35,15 @@ public:
 	EventCommandBaseWidget(ProjectData& project, QWidget* parent);
 
 	virtual void setData(lcf::rpg::EventCommand* cmd);
+
+	void connectParameterHandler(QButtonGroup* group, int index);
+	void connectParameterHandler(RpgComboBoxBase* combo, int index);
+	void connectParameterHandler(QSpinBox* spin, int index);
+	void connectParameterHandler(QCheckBox* combo, int index);
+
+signals:
+	void parameterChanged(int, int);
+	void stringParameterChanged(const QString&);
 
 protected:
 	ProjectData& m_project;

--- a/src/ui/event/event_command_base_widget.h
+++ b/src/ui/event/event_command_base_widget.h
@@ -31,7 +31,7 @@ class EventCommandBaseWidget : public QWidget
 public:
 	EventCommandBaseWidget(ProjectData& project, QWidget* parent);
 
-	void setData(lcf::rpg::EventCommand* cmd);
+	virtual void setData(lcf::rpg::EventCommand* cmd);
 
 protected:
 	ProjectData& m_project;

--- a/src/ui/event/event_commands_widget.cpp
+++ b/src/ui/event/event_commands_widget.cpp
@@ -98,14 +98,19 @@ void EventCommandsWidget::setDataInternal(ProjectData& project, T* event) {
 	expandAll();
 }
 
+template<typename T>
+WidgetAsDialogWrapper<T, lcf::rpg::EventCommand>* make_evt_dialog(ProjectData* prj, lcf::rpg::EventCommand& cmd, EventCommandsWidget* self) {
+	return new WidgetAsDialogWrapper<T, lcf::rpg::EventCommand>(*prj, cmd, self);
+}
+
 void EventCommandsWidget::editEvent(QTreeWidgetItem* item, int column) {
 	assert(column == 0);
 
 	using Cmd = lcf::rpg::EventCommand::Code;
 
 	auto& cmd = *static_cast<lcf::rpg::EventCommand*>(item->data(column, Qt::UserRole).value<void*>());
-	std::unique_ptr<QDialog> dialog;
-
+	QWidget* evt_widget = nullptr;
+/*
 	switch (static_cast<Cmd>(cmd.code))	{
 		case Cmd::ChangeGold: dialog = std::make_unique<ChangeMoneyWidgetWidget>(this, cmd); break;
 		case Cmd::ChangeItems: dialog = std::make_unique<ChangeItemWidget>(this, cmd); break;
@@ -120,8 +125,16 @@ void EventCommandsWidget::editEvent(QTreeWidgetItem* item, int column) {
 		case Cmd::ControlVars: dialog = std::make_unique<VariableOperationsWidget>(this, cmd); break;
 		default: editRawEvent(item, column, true); return;
 	}
+*/
+	std::unique_ptr<QDialog> evt_dialog;
 
-	dialog->exec();
+	switch (static_cast<Cmd>(cmd.code))	{
+		case Cmd::MessageOptions: evt_dialog.reset(make_evt_dialog<MessageOptionsWidget>(m_project, cmd, this)); break;
+		case Cmd::InputNumber: evt_dialog.reset(make_evt_dialog<InputNumberWidget>(m_project, cmd, this)); break;
+		default: editRawEvent(item, column, true); return;
+	}
+
+	evt_dialog->exec();
 
 	currentItem()->setData(column, Qt::DisplayRole, Stringizer::stringize(cmd));
 }

--- a/src/ui/event/event_commands_widget.cpp
+++ b/src/ui/event/event_commands_widget.cpp
@@ -109,7 +109,30 @@ void EventCommandsWidget::editEvent(QTreeWidgetItem* item, int column) {
 	using Cmd = lcf::rpg::EventCommand::Code;
 
 	auto& cmd = *static_cast<lcf::rpg::EventCommand*>(item->data(column, Qt::UserRole).value<void*>());
-	QWidget* evt_widget = nullptr;
+
+	// Commands with no configuration
+	switch (static_cast<Cmd>(cmd.code))	{
+		case Cmd::EnterExitVehicle:
+		case Cmd::MemorizeBGM:
+		case Cmd::PlayMemorizedBGM:
+		case Cmd::OpenSaveMenu:
+		case Cmd::OpenMainMenu:
+		case Cmd::Loop:
+		case Cmd::BreakLoop:
+		case Cmd::EndEventProcessing:
+		case Cmd::EraseEvent:
+		case Cmd::GameOver:
+		case Cmd::ReturntoTitleScreen:
+		case Cmd::OpenLoadMenu:
+		case Cmd::ExitGame:
+		case Cmd::ToggleAtbMode:
+		case Cmd::ToggleFullscreen:
+		case Cmd::OpenVideoOptions:
+			return;
+		default:
+			break;
+	}
+
 /*
 	switch (static_cast<Cmd>(cmd.code))	{
 		case Cmd::ChangeGold: dialog = std::make_unique<ChangeMoneyWidgetWidget>(this, cmd); break;

--- a/src/ui/event/event_commands_widget.cpp
+++ b/src/ui/event/event_commands_widget.cpp
@@ -162,7 +162,31 @@ void EventCommandsWidget::editEvent(QTreeWidgetItem* item, int column) {
 
 	std::unique_ptr<QDialog> evt_dialog;
 
-	EventCommandList evt_lst(*m_commands, item->text(1).toInt());
+	int index = item->text(1).toInt();
+
+	// Event commands that need special handling
+	// FIXME: Causes a visual glitch because the wrong item is updated in the Tree
+	switch (static_cast<Cmd>(cmd.code)) {
+		case Cmd::ShowMessage_2: {
+			// Search for a ShowMessage command above and invoke it instead
+			for (int i = index - 1; i >= 0; --i) {
+				auto& cur_cmd = (*m_commands)[i];
+				auto code = static_cast<Cmd>(cur_cmd.code);
+				if (code == Cmd::ShowMessage_2) {
+					continue;
+				} else if (static_cast<Cmd>(cur_cmd.code) == Cmd::ShowMessage) {
+					index = i;
+					cmd = cur_cmd;
+					break;
+				} else {
+					Q_ASSERT(false && "Event list corrupted: ShowMessage_2 without ShowMessage");
+				}
+			}
+		}
+		default: break;
+	}
+
+	EventCommandList evt_lst(*m_commands, index);
 
 	switch (static_cast<Cmd>(cmd.code))	{
 		//case Cmd::CallCommonEvent: evt_dialog.reset(make_evt_dialog<CallCommonEventWidget>(m_project, cmd, this)); break;
@@ -255,7 +279,6 @@ void EventCommandsWidget::editEvent(QTreeWidgetItem* item, int column) {
 		//case Cmd::ChangeBattleBG: evt_dialog.reset(make_evt_dialog<ChangeBattleBGWidget>(m_project, cmd, this)); break;
 		//case Cmd::ShowBattleAnimation_B: evt_dialog.reset(make_evt_dialog<ShowBattleAnimation_BWidget>(m_project, cmd, this)); break;
 		//case Cmd::ConditionalBranch_B: evt_dialog.reset(make_evt_dialog<ConditionalBranch_BWidget>(m_project, cmd, this)); break;
-		//case Cmd::ShowMessage_2: evt_dialog.reset(make_evt_dialog<ShowMessage_2Widget>(m_project, cmd, this)); break;
 		//case Cmd::Comment_2: evt_dialog.reset(make_evt_dialog<Comment_2Widget>(m_project, cmd, this)); break;
 		//case Cmd::Maniac_GetSaveInfo: evt_dialog.reset(make_evt_dialog<Maniac_GetSaveInfoWidget>(m_project, cmd, this)); break;
 		//case Cmd::Maniac_Save: evt_dialog.reset(make_evt_dialog<Maniac_SaveWidget>(m_project, cmd, this)); break;

--- a/src/ui/event/event_commands_widget.cpp
+++ b/src/ui/event/event_commands_widget.cpp
@@ -112,7 +112,10 @@ void EventCommandsWidget::editEvent(QTreeWidgetItem* item, int column) {
 
 	// Commands with no configuration
 	switch (static_cast<Cmd>(cmd.code))	{
+		case Cmd::END:
 		case Cmd::EnterExitVehicle:
+		case Cmd::ProceedWithMovement:
+		case Cmd::HaltAllMovement:
 		case Cmd::MemorizeBGM:
 		case Cmd::PlayMemorizedBGM:
 		case Cmd::OpenSaveMenu:
@@ -128,34 +131,143 @@ void EventCommandsWidget::editEvent(QTreeWidgetItem* item, int column) {
 		case Cmd::ToggleAtbMode:
 		case Cmd::ToggleFullscreen:
 		case Cmd::OpenVideoOptions:
+		case Cmd::TerminateBattle:
+		case Cmd::ShowChoiceOption:
+		case Cmd::ShowChoiceEnd:
+		case Cmd::ElseBranch:
+		case Cmd::EndBranch:
+		case Cmd::EndLoop:
+		case Cmd::EndBattle:
+		case Cmd::EndShop:
+		case Cmd::VictoryHandler:
+		case Cmd::EscapeHandler:
+		case Cmd::DefeatHandler:
+		case Cmd::Transaction:
+		case Cmd::NoTransaction:
+		case Cmd::Stay:
+		case Cmd::NoStay:
+		case Cmd::EndInn:
+		case Cmd::ElseBranch_B:
+		case Cmd::EndBranch_B:
 			return;
 		default:
 			break;
 	}
 
-/*
-	switch (static_cast<Cmd>(cmd.code))	{
-		case Cmd::ChangeGold: dialog = std::make_unique<ChangeMoneyWidgetWidget>(this, cmd); break;
-		case Cmd::ChangeItems: dialog = std::make_unique<ChangeItemWidget>(this, cmd); break;
-		case Cmd::ChangePartyMembers: dialog = std::make_unique<ChangePartyWidget>(this, cmd); break;
-		case Cmd::ChangeExp: dialog = std::make_unique<ChangeExperienceWidget>(this, cmd); break;
-		case Cmd::ChangeFaceGraphic: dialog = std::make_unique<FaceGraphicsWidget>(this, cmd); break;
-		case Cmd::InputNumber: dialog = std::make_unique<InputNumberWidget>(this, cmd); break;
-		case Cmd::MessageOptions: dialog = std::make_unique<MessageOptionsWidget>(this, cmd); break;
-		case Cmd::ShowChoice: dialog = std::make_unique<ShowChoicesWidget>(this, cmd); break;
-		case Cmd::ShowMessage: dialog = std::make_unique<ShowMessageWidget>(this, cmd); break;
-		case Cmd::ControlSwitches: dialog = std::make_unique<SwitchOperationsWidget>(this, cmd); break;
-		case Cmd::ControlVars: dialog = std::make_unique<VariableOperationsWidget>(this, cmd); break;
-		default: editRawEvent(item, column, true); return;
-	}
-*/
 	std::unique_ptr<QDialog> evt_dialog;
 
 	switch (static_cast<Cmd>(cmd.code))	{
+		//case Cmd::CallCommonEvent: evt_dialog.reset(make_evt_dialog<CallCommonEventWidget>(m_project, cmd, this)); break;
+		//case Cmd::ForceFlee: evt_dialog.reset(make_evt_dialog<ForceFleeWidget>(m_project, cmd, this)); break;
+		//case Cmd::EnableCombo: evt_dialog.reset(make_evt_dialog<EnableComboWidget>(m_project, cmd, this)); break;
+		//case Cmd::ChangeClass: evt_dialog.reset(make_evt_dialog<ChangeClassWidget>(m_project, cmd, this)); break;
+		//case Cmd::ChangeBattleCommands: evt_dialog.reset(make_evt_dialog<ChangeBattleCommandsWidget>(m_project, cmd, this)); break;
+		//case Cmd::ShowMessage: evt_dialog.reset(make_evt_dialog<ShowMessageWidget>(m_project, cmd, this)); break;
 		case Cmd::MessageOptions: evt_dialog.reset(make_evt_dialog<MessageOptionsWidget>(m_project, cmd, this)); break;
-		case Cmd::InputNumber: evt_dialog.reset(make_evt_dialog<InputNumberWidget>(m_project, cmd, this)); break;
+		//case Cmd::ChangeFaceGraphic: evt_dialog.reset(make_evt_dialog<ChangeFaceGraphicWidget>(m_project, cmd, this)); break;
+		//case Cmd::ShowChoice: evt_dialog.reset(make_evt_dialog<ShowChoiceWidget>(m_project, cmd, this)); break;
+		//case Cmd::InputNumber: evt_dialog.reset(make_evt_dialog<InputNumberWidget>(m_project, cmd, this)); break;
+		//case Cmd::ControlSwitches: evt_dialog.reset(make_evt_dialog<ControlSwitchesWidget>(m_project, cmd, this)); break;
+		//case Cmd::ControlVars: evt_dialog.reset(make_evt_dialog<ControlVarsWidget>(m_project, cmd, this)); break;
+		//case Cmd::TimerOperation: evt_dialog.reset(make_evt_dialog<TimerOperationWidget>(m_project, cmd, this)); break;
+		//case Cmd::ChangeGold: evt_dialog.reset(make_evt_dialog<ChangeGoldWidget>(m_project, cmd, this)); break;
 		case Cmd::ChangeItems: evt_dialog.reset(make_evt_dialog<ChangeItemWidget>(m_project, cmd, this)); break;
+		//case Cmd::ChangePartyMembers: evt_dialog.reset(make_evt_dialog<ChangePartyMembersWidget>(m_project, cmd, this)); break;
+		//case Cmd::ChangeExp: evt_dialog.reset(make_evt_dialog<ChangeExpWidget>(m_project, cmd, this)); break;
+		//case Cmd::ChangeLevel: evt_dialog.reset(make_evt_dialog<ChangeLevelWidget>(m_project, cmd, this)); break;
+		//case Cmd::ChangeParameters: evt_dialog.reset(make_evt_dialog<ChangeParametersWidget>(m_project, cmd, this)); break;
+		//case Cmd::ChangeSkills: evt_dialog.reset(make_evt_dialog<ChangeSkillsWidget>(m_project, cmd, this)); break;
+		//case Cmd::ChangeEquipment: evt_dialog.reset(make_evt_dialog<ChangeEquipmentWidget>(m_project, cmd, this)); break;
+		//case Cmd::ChangeHP: evt_dialog.reset(make_evt_dialog<ChangeHPWidget>(m_project, cmd, this)); break;
+		//case Cmd::ChangeSP: evt_dialog.reset(make_evt_dialog<ChangeSPWidget>(m_project, cmd, this)); break;
+		//case Cmd::ChangeCondition: evt_dialog.reset(make_evt_dialog<ChangeConditionWidget>(m_project, cmd, this)); break;
 		case Cmd::FullHeal: evt_dialog.reset(make_evt_dialog<FullHealWidget>(m_project, cmd, this)); break;
+		//case Cmd::SimulatedAttack: evt_dialog.reset(make_evt_dialog<SimulatedAttackWidget>(m_project, cmd, this)); break;
+		//case Cmd::ChangeHeroName: evt_dialog.reset(make_evt_dialog<ChangeHeroNameWidget>(m_project, cmd, this)); break;
+		//case Cmd::ChangeHeroTitle: evt_dialog.reset(make_evt_dialog<ChangeHeroTitleWidget>(m_project, cmd, this)); break;
+		//case Cmd::ChangeSpriteAssociation: evt_dialog.reset(make_evt_dialog<ChangeSpriteAssociationWidget>(m_project, cmd, this)); break;
+		//case Cmd::ChangeActorFace: evt_dialog.reset(make_evt_dialog<ChangeActorFaceWidget>(m_project, cmd, this)); break;
+		//case Cmd::ChangeVehicleGraphic: evt_dialog.reset(make_evt_dialog<ChangeVehicleGraphicWidget>(m_project, cmd, this)); break;
+		//case Cmd::ChangeSystemBGM: evt_dialog.reset(make_evt_dialog<ChangeSystemBgmWidget>(m_project, cmd, this)); break;
+		//case Cmd::ChangeSystemSFX: evt_dialog.reset(make_evt_dialog<ChangeSystemSfxWidget>(m_project, cmd, this)); break;
+		//case Cmd::ChangeSystemGraphics: evt_dialog.reset(make_evt_dialog<ChangeSystemGraphicsWidget>(m_project, cmd, this)); break;
+		//case Cmd::ChangeScreenTransitions: evt_dialog.reset(make_evt_dialog<ChangeScreenTransitionsWidget>(m_project, cmd, this)); break;
+		//case Cmd::EnemyEncounter: evt_dialog.reset(make_evt_dialog<EnemyEncounterWidget>(m_project, cmd, this)); break;
+		//case Cmd::OpenShop: evt_dialog.reset(make_evt_dialog<OpenShopWidget>(m_project, cmd, this)); break;
+		//case Cmd::ShowInn: evt_dialog.reset(make_evt_dialog<ShowInnWidget>(m_project, cmd, this)); break;
+		//case Cmd::EnterHeroName: evt_dialog.reset(make_evt_dialog<EnterHeroNameWidget>(m_project, cmd, this)); break;
+		//case Cmd::Teleport: evt_dialog.reset(make_evt_dialog<TeleportWidget>(m_project, cmd, this)); break;
+		//case Cmd::MemorizeLocation: evt_dialog.reset(make_evt_dialog<MemorizeLocationWidget>(m_project, cmd, this)); break;
+		//case Cmd::RecallToLocation: evt_dialog.reset(make_evt_dialog<RecallToLocationWidget>(m_project, cmd, this)); break;
+		//case Cmd::EnterExitVehicle: evt_dialog.reset(make_evt_dialog<EnterExitVehicleWidget>(m_project, cmd, this)); break;
+		//case Cmd::SetVehicleLocation: evt_dialog.reset(make_evt_dialog<SetVehicleLocationWidget>(m_project, cmd, this)); break;
+		//case Cmd::ChangeEventLocation: evt_dialog.reset(make_evt_dialog<ChangeEventLocationWidget>(m_project, cmd, this)); break;
+		//case Cmd::TradeEventLocations: evt_dialog.reset(make_evt_dialog<TradeEventLocationsWidget>(m_project, cmd, this)); break;
+		//case Cmd::StoreTerrainID: evt_dialog.reset(make_evt_dialog<StoreTerrainIdWidget>(m_project, cmd, this)); break;
+		//case Cmd::StoreEventID: evt_dialog.reset(make_evt_dialog<StoreEventIdWidget>(m_project, cmd, this)); break;
+		//case Cmd::EraseScreen: evt_dialog.reset(make_evt_dialog<EraseScreenWidget>(m_project, cmd, this)); break;
+		//case Cmd::ShowScreen: evt_dialog.reset(make_evt_dialog<ShowScreenWidget>(m_project, cmd, this)); break;
+		//case Cmd::TintScreen: evt_dialog.reset(make_evt_dialog<TintScreenWidget>(m_project, cmd, this)); break;
+		//case Cmd::FlashScreen: evt_dialog.reset(make_evt_dialog<FlashScreenWidget>(m_project, cmd, this)); break;
+		//case Cmd::ShakeScreen: evt_dialog.reset(make_evt_dialog<ShakeScreenWidget>(m_project, cmd, this)); break;
+		//case Cmd::PanScreen: evt_dialog.reset(make_evt_dialog<PanScreenWidget>(m_project, cmd, this)); break;
+		//case Cmd::WeatherEffects: evt_dialog.reset(make_evt_dialog<WeatherEffectsWidget>(m_project, cmd, this)); break;
+		//case Cmd::ShowPicture: evt_dialog.reset(make_evt_dialog<ShowPictureWidget>(m_project, cmd, this)); break;
+		//case Cmd::MovePicture: evt_dialog.reset(make_evt_dialog<MovePictureWidget>(m_project, cmd, this)); break;
+		//case Cmd::ErasePicture: evt_dialog.reset(make_evt_dialog<ErasePictureWidget>(m_project, cmd, this)); break;
+		//case Cmd::ShowBattleAnimation: evt_dialog.reset(make_evt_dialog<ShowBattleAnimationWidget>(m_project, cmd, this)); break;
+		//case Cmd::SpriteTransparency: evt_dialog.reset(make_evt_dialog<SpriteTransparencyWidget>(m_project, cmd, this)); break;
+		//case Cmd::FlashSprite: evt_dialog.reset(make_evt_dialog<FlashSpriteWidget>(m_project, cmd, this)); break;
+		//case Cmd::MoveEvent: evt_dialog.reset(make_evt_dialog<MoveEventWidget>(m_project, cmd, this)); break;
+		//case Cmd::Wait: evt_dialog.reset(make_evt_dialog<WaitWidget>(m_project, cmd, this)); break;
+		//case Cmd::PlayBGM: evt_dialog.reset(make_evt_dialog<PlayBgmWidget>(m_project, cmd, this)); break;
+		//case Cmd::FadeOutBGM: evt_dialog.reset(make_evt_dialog<FadeOutBgmWidget>(m_project, cmd, this)); break;
+		//case Cmd::PlaySound: evt_dialog.reset(make_evt_dialog<PlaySoundWidget>(m_project, cmd, this)); break;
+		//case Cmd::PlayMovie: evt_dialog.reset(make_evt_dialog<PlayMovieWidget>(m_project, cmd, this)); break;
+		//case Cmd::KeyInputProc: evt_dialog.reset(make_evt_dialog<KeyInputProcWidget>(m_project, cmd, this)); break;
+		//case Cmd::ChangeMapTileset: evt_dialog.reset(make_evt_dialog<ChangeMapTilesetWidget>(m_project, cmd, this)); break;
+		//case Cmd::ChangePBG: evt_dialog.reset(make_evt_dialog<ChangePBGWidget>(m_project, cmd, this)); break;
+		//case Cmd::ChangeEncounterRate: evt_dialog.reset(make_evt_dialog<ChangeEncounterRateWidget>(m_project, cmd, this)); break;
+		//case Cmd::TileSubstitution: evt_dialog.reset(make_evt_dialog<TileSubstitutionWidget>(m_project, cmd, this)); break;
+		//case Cmd::TeleportTargets: evt_dialog.reset(make_evt_dialog<TeleportTargetsWidget>(m_project, cmd, this)); break;
+		//case Cmd::ChangeTeleportAccess: evt_dialog.reset(make_evt_dialog<ChangeTeleportAccessWidget>(m_project, cmd, this)); break;
+		//case Cmd::EscapeTarget: evt_dialog.reset(make_evt_dialog<EscapeTargetWidget>(m_project, cmd, this)); break;
+		//case Cmd::ChangeEscapeAccess: evt_dialog.reset(make_evt_dialog<ChangeEscapeAccessWidget>(m_project, cmd, this)); break;
+		//case Cmd::ChangeSaveAccess: evt_dialog.reset(make_evt_dialog<ChangeSaveAccessWidget>(m_project, cmd, this)); break;
+		//case Cmd::ChangeMainMenuAccess: evt_dialog.reset(make_evt_dialog<ChangeMainMenuAccessWidget>(m_project, cmd, this)); break;
+		//case Cmd::ConditionalBranch: evt_dialog.reset(make_evt_dialog<ConditionalBranchWidget>(m_project, cmd, this)); break;
+		//case Cmd::Label: evt_dialog.reset(make_evt_dialog<LabelWidget>(m_project, cmd, this)); break;
+		//case Cmd::JumpToLabel: evt_dialog.reset(make_evt_dialog<JumpToLabelWidget>(m_project, cmd, this)); break;
+		//case Cmd::CallEvent: evt_dialog.reset(make_evt_dialog<CallEventWidget>(m_project, cmd, this)); break;
+		//case Cmd::Comment: evt_dialog.reset(make_evt_dialog<CommentWidget>(m_project, cmd, this)); break;
+		//case Cmd::ChangeMonsterHP: evt_dialog.reset(make_evt_dialog<ChangeMonsterHPWidget>(m_project, cmd, this)); break;
+		//case Cmd::ChangeMonsterMP: evt_dialog.reset(make_evt_dialog<ChangeMonsterMPWidget>(m_project, cmd, this)); break;
+		//case Cmd::ChangeMonsterCondition: evt_dialog.reset(make_evt_dialog<ChangeMonsterConditionWidget>(m_project, cmd, this)); break;
+		//case Cmd::ShowHiddenMonster: evt_dialog.reset(make_evt_dialog<ShowHiddenMonsterWidget>(m_project, cmd, this)); break;
+		//case Cmd::ChangeBattleBG: evt_dialog.reset(make_evt_dialog<ChangeBattleBGWidget>(m_project, cmd, this)); break;
+		//case Cmd::ShowBattleAnimation_B: evt_dialog.reset(make_evt_dialog<ShowBattleAnimation_BWidget>(m_project, cmd, this)); break;
+		//case Cmd::ConditionalBranch_B: evt_dialog.reset(make_evt_dialog<ConditionalBranch_BWidget>(m_project, cmd, this)); break;
+		//case Cmd::ShowMessage_2: evt_dialog.reset(make_evt_dialog<ShowMessage_2Widget>(m_project, cmd, this)); break;
+		//case Cmd::Comment_2: evt_dialog.reset(make_evt_dialog<Comment_2Widget>(m_project, cmd, this)); break;
+		//case Cmd::Maniac_GetSaveInfo: evt_dialog.reset(make_evt_dialog<Maniac_GetSaveInfoWidget>(m_project, cmd, this)); break;
+		//case Cmd::Maniac_Save: evt_dialog.reset(make_evt_dialog<Maniac_SaveWidget>(m_project, cmd, this)); break;
+		//case Cmd::Maniac_Load: evt_dialog.reset(make_evt_dialog<Maniac_LoadWidget>(m_project, cmd, this)); break;
+		//case Cmd::Maniac_EndLoadProcess: evt_dialog.reset(make_evt_dialog<Maniac_EndLoadProcessWidget>(m_project, cmd, this)); break;
+		//case Cmd::Maniac_GetMousePosition: evt_dialog.reset(make_evt_dialog<Maniac_GetMousePositionWidget>(m_project, cmd, this)); break;
+		//case Cmd::Maniac_SetMousePosition: evt_dialog.reset(make_evt_dialog<Maniac_SetMousePositionWidget>(m_project, cmd, this)); break;
+		//case Cmd::Maniac_ShowStringPicture: evt_dialog.reset(make_evt_dialog<Maniac_ShowStringPictureWidget>(m_project, cmd, this)); break;
+		//case Cmd::Maniac_GetPictureInfo: evt_dialog.reset(make_evt_dialog<Maniac_GetPictureInfoWidget>(m_project, cmd, this)); break;
+		//case Cmd::Maniac_ControlBattle: evt_dialog.reset(make_evt_dialog<Maniac_ControlBattleWidget>(m_project, cmd, this)); break;
+		//case Cmd::Maniac_ControlAtbGauge: evt_dialog.reset(make_evt_dialog<Maniac_ControlAtbGaugeWidget>(m_project, cmd, this)); break;
+		//case Cmd::Maniac_ChangeBattleCommandEx: evt_dialog.reset(make_evt_dialog<Maniac_ChangeBattleCommandExWidget>(m_project, cmd, this)); break;
+		//case Cmd::Maniac_GetBattleInfo: evt_dialog.reset(make_evt_dialog<Maniac_GetBattleInfoWidget>(m_project, cmd, this)); break;
+		//case Cmd::Maniac_ControlVarArray: evt_dialog.reset(make_evt_dialog<Maniac_ControlVarArrayWidget>(m_project, cmd, this)); break;
+		//case Cmd::Maniac_KeyInputProcEx: evt_dialog.reset(make_evt_dialog<Maniac_KeyInputProcExWidget>(m_project, cmd, this)); break;
+		//case Cmd::Maniac_RewriteMap: evt_dialog.reset(make_evt_dialog<Maniac_RewriteMapWidget>(m_project, cmd, this)); break;
+		//case Cmd::Maniac_ControlGlobalSave: evt_dialog.reset(make_evt_dialog<Maniac_ControlGlobalSaveWidget>(m_project, cmd, this)); break;
+		//case Cmd::Maniac_ChangePictureId: evt_dialog.reset(make_evt_dialog<Maniac_ChangePictureIdWidget>(m_project, cmd, this)); break;
+		//case Cmd::Maniac_SetGameOption: evt_dialog.reset(make_evt_dialog<Maniac_SetGameOptionWidget>(m_project, cmd, this)); break;
+		//case Cmd::Maniac_CallCommand: evt_dialog.reset(make_evt_dialog<Maniac_CallCommandWidget>(m_project, cmd, this)); break;
 		default: editRawEvent(item, column, true); return;
 	}
 

--- a/src/ui/event/event_commands_widget.cpp
+++ b/src/ui/event/event_commands_widget.cpp
@@ -173,8 +173,8 @@ void EventCommandsWidget::editEvent(QTreeWidgetItem* item, int column) {
 		//case Cmd::ChangeGold: evt_dialog.reset(make_evt_dialog<ChangeGoldWidget>(m_project, cmd, this)); break;
 		case Cmd::ChangeItems: evt_dialog.reset(make_evt_dialog<ChangeItemWidget>(m_project, cmd, this)); break;
 		//case Cmd::ChangePartyMembers: evt_dialog.reset(make_evt_dialog<ChangePartyMembersWidget>(m_project, cmd, this)); break;
-		//case Cmd::ChangeExp: evt_dialog.reset(make_evt_dialog<ChangeExpWidget>(m_project, cmd, this)); break;
-		//case Cmd::ChangeLevel: evt_dialog.reset(make_evt_dialog<ChangeLevelWidget>(m_project, cmd, this)); break;
+		case Cmd::ChangeExp: evt_dialog.reset(make_evt_dialog<ChangeExperienceWidget>(m_project, cmd, this)); break;
+		case Cmd::ChangeLevel: evt_dialog.reset(make_evt_dialog<ChangeLevelWidget>(m_project, cmd, this)); break;
 		//case Cmd::ChangeParameters: evt_dialog.reset(make_evt_dialog<ChangeParametersWidget>(m_project, cmd, this)); break;
 		//case Cmd::ChangeSkills: evt_dialog.reset(make_evt_dialog<ChangeSkillsWidget>(m_project, cmd, this)); break;
 		//case Cmd::ChangeEquipment: evt_dialog.reset(make_evt_dialog<ChangeEquipmentWidget>(m_project, cmd, this)); break;

--- a/src/ui/event/event_commands_widget.cpp
+++ b/src/ui/event/event_commands_widget.cpp
@@ -17,6 +17,7 @@
 
 #include "event_commands_widget.h"
 #include "stringizer.h"
+#include "model/event_command_list.h"
 #include "ui/commands/all_commands.h"
 #include "ui/event/event_raw_widget.h"
 #include "ui/common/widget_as_dialog_wrapper.h"
@@ -103,6 +104,11 @@ WidgetAsDialogWrapper<T, lcf::rpg::EventCommand>* make_evt_dialog(ProjectData* p
 	return new WidgetAsDialogWrapper<T, lcf::rpg::EventCommand>(*prj, cmd, self);
 }
 
+template<typename T>
+WidgetAsDialogWrapper<T, EventCommandList>* make_complex_evt_dialog(ProjectData* prj, EventCommandList& commands, EventCommandsWidget* self) {
+	return new WidgetAsDialogWrapper<T, EventCommandList>(*prj, commands, self);
+}
+
 void EventCommandsWidget::editEvent(QTreeWidgetItem* item, int column) {
 	assert(column == 0);
 
@@ -156,13 +162,15 @@ void EventCommandsWidget::editEvent(QTreeWidgetItem* item, int column) {
 
 	std::unique_ptr<QDialog> evt_dialog;
 
+	EventCommandList evt_lst(*m_commands, item->text(1).toInt());
+
 	switch (static_cast<Cmd>(cmd.code))	{
 		//case Cmd::CallCommonEvent: evt_dialog.reset(make_evt_dialog<CallCommonEventWidget>(m_project, cmd, this)); break;
 		//case Cmd::ForceFlee: evt_dialog.reset(make_evt_dialog<ForceFleeWidget>(m_project, cmd, this)); break;
 		//case Cmd::EnableCombo: evt_dialog.reset(make_evt_dialog<EnableComboWidget>(m_project, cmd, this)); break;
 		//case Cmd::ChangeClass: evt_dialog.reset(make_evt_dialog<ChangeClassWidget>(m_project, cmd, this)); break;
 		//case Cmd::ChangeBattleCommands: evt_dialog.reset(make_evt_dialog<ChangeBattleCommandsWidget>(m_project, cmd, this)); break;
-		//case Cmd::ShowMessage: evt_dialog.reset(make_evt_dialog<ShowMessageWidget>(m_project, cmd, this)); break;
+		case Cmd::ShowMessage: evt_dialog.reset(make_complex_evt_dialog<ShowMessageWidget>(m_project, evt_lst, this)); break;
 		case Cmd::MessageOptions: evt_dialog.reset(make_evt_dialog<MessageOptionsWidget>(m_project, cmd, this)); break;
 		//case Cmd::ChangeFaceGraphic: evt_dialog.reset(make_evt_dialog<ChangeFaceGraphicWidget>(m_project, cmd, this)); break;
 		//case Cmd::ShowChoice: evt_dialog.reset(make_evt_dialog<ShowChoiceWidget>(m_project, cmd, this)); break;

--- a/src/ui/event/event_commands_widget.cpp
+++ b/src/ui/event/event_commands_widget.cpp
@@ -131,6 +131,8 @@ void EventCommandsWidget::editEvent(QTreeWidgetItem* item, int column) {
 	switch (static_cast<Cmd>(cmd.code))	{
 		case Cmd::MessageOptions: evt_dialog.reset(make_evt_dialog<MessageOptionsWidget>(m_project, cmd, this)); break;
 		case Cmd::InputNumber: evt_dialog.reset(make_evt_dialog<InputNumberWidget>(m_project, cmd, this)); break;
+		case Cmd::ChangeItems: evt_dialog.reset(make_evt_dialog<ChangeItemWidget>(m_project, cmd, this)); break;
+		case Cmd::FullHeal: evt_dialog.reset(make_evt_dialog<FullHealWidget>(m_project, cmd, this)); break;
 		default: editRawEvent(item, column, true); return;
 	}
 


### PR DESCRIPTION
I implemented a system that allows to implement the simple event commands with the least amount of code via magic (tm).

The event Ui scans for GUI that ends on ``_argN`` where (N = parameter, use X for string). All it finds is auto-attached.

--------

I also invented a OperandWidget that provides these three typical use cases:

- Value or Variable
- LCF Object or Variable
- Entire Party, Actor or Variable

``_argN`` also attached here (uses subsequent values because it takes two args, so 2 will use 2 as operand and 3 as value)

------

Some GUI

Of course I recycle the RpgComboBox, so you profit from type-to-search and a "..." button to open a database window for direct editing.

![3-fs8](https://user-images.githubusercontent.com/1331889/105646496-8f7c5300-5ea0-11eb-954b-5dfb9bdaa4bb.png)
![2-fs8](https://user-images.githubusercontent.com/1331889/105646495-8f7c5300-5ea0-11eb-8d59-2744a6ae68b0.png)
![1-fs8](https://user-images.githubusercontent.com/1331889/105646494-8ee3bc80-5ea0-11eb-9d30-9c57f1860b71.png)

--------

Some code examples (boilerplate omitted):

Message Options. Unfortunately QtDesigner has no way to assign a button ID, otherwise this could be omitted :( 

```cpp
int i = 0;
for (auto& button : { ui->buttonTypeNormal, ui->buttonTypeTransparent }) {
	ui->groupWindowType_arg0->setId(button, i++);
}

i = 0;
for (auto& button : { ui->buttonPositionTop, ui->buttonPositionMiddle, ui->buttonPositionBottom }) {
	ui->groupWindowPos_arg1->setId(button, i++);
}
```

Change Item:

```cpp
int i = 0;
for (auto& button : { ui->radioOpAdd, ui->radioOpRemove }) {
	ui->groupOp_arg0->setId(button, i++);
}
```

