### PR TITLE
Implement Music and Sound Picker

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,6 +163,8 @@ add_library(${PROJECT_NAME} STATIC
 	src/ui/common/picker_scene.h
 	src/ui/common/rpg_combobox.h
 	src/ui/common/rpg_model.h
+	src/ui/common/rpg_audio_lineedit.cpp
+	src/ui/common/rpg_audio_lineedit.h
 	src/ui/common/rpg_slider.cpp
 	src/ui/common/rpg_slider.h
 	src/ui/common/rpg_spinbox.cpp
@@ -290,6 +292,9 @@ add_library(${PROJECT_NAME} STATIC
 	src/ui/other/splash_dialog.ui
 	src/ui/other/volumebutton.cpp
 	src/ui/other/volumebutton.h
+	src/ui/picker/picker_audio_widget.cpp
+	src/ui/picker/picker_audio_widget.h
+	src/ui/picker/picker_audio_widget.ui
 	src/ui/picker/picker_child_widget.cpp
 	src/ui/picker/picker_child_widget.h
 	src/ui/picker/picker_charset_widget.cpp

--- a/src/ui/common/rpg_audio_lineedit.cpp
+++ b/src/ui/common/rpg_audio_lineedit.cpp
@@ -1,0 +1,98 @@
+/*
+ * This file is part of EasyRPG Editor.
+ *
+ * EasyRPG Editor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Editor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Editor. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "rpg_audio_lineedit.h"
+
+#include <QHBoxLayout>
+#include <QLineEdit>
+#include <QPushButton>
+#include <lcf/rpg/music.h>
+#include <lcf/rpg/sound.h>
+
+#include "defines.h"
+#include "model/project_data.h"
+#include "ui/picker/picker_audio_widget.h"
+#include "ui/picker/picker_dialog.h"
+
+RpgAudioLineEdit::RpgAudioLineEdit(QWidget *parent) : QWidget(parent) {
+	m_lineEdit = new QLineEdit(this);
+	m_lineEdit->setReadOnly(true);
+	m_editButton = new QPushButton("...", this);
+
+	auto* layout = new QHBoxLayout(this);
+	layout->addWidget(m_lineEdit);
+	layout->addWidget(m_editButton);
+
+	QSizePolicy policy;
+	policy.setHorizontalPolicy(QSizePolicy::Maximum);
+	m_editButton->setSizePolicy(policy);
+}
+
+QLineEdit* RpgAudioLineEdit::lineEdit() const {
+	return m_lineEdit;
+}
+
+void RpgAudioLineEdit::makeModel(ProjectData& project) {
+	m_project = &project;
+
+	QObject::connect(m_editButton, &QPushButton::pressed, [&] {
+		editPressed();
+	});
+}
+
+void RpgMusicLineEdit::editPressed() {
+	Q_ASSERT_X(m_music, "RpgMusicLineEdit::editPressed", "bindMusic not called");
+
+	auto* widget = new PickerAudioWidget(*m_music, this);
+	PickerDialog dialog(*m_project, FileFinder::FileType::Music, widget, this);
+	QObject::connect(&dialog, &PickerDialog::fileSelected, [&](const QString& baseName) {
+		m_lineEdit->setText(baseName);
+		m_music->name = baseName.toStdString();
+		m_music->fadein = widget->fadeInTime();
+		m_music->volume = widget->volume();
+		m_music->tempo = widget->tempo();
+		m_music->balance = widget->balance();
+	});
+	dialog.setDirectoryAndFile(MUSIC, m_lineEdit->text());
+	dialog.exec();
+}
+
+void RpgMusicLineEdit::bindMusic(lcf::rpg::Music& music) {
+	m_music = &music;
+	m_lineEdit->setText(QString::fromStdString(music.name));
+}
+
+void RpgSoundLineEdit::editPressed() {
+	Q_ASSERT_X(m_sound, "RpgSoundLineEdit::editPressed", "bindSound not called");
+
+	auto* widget = new PickerAudioWidget(*m_sound, this);
+	PickerDialog dialog(*m_project, FileFinder::FileType::Sound, widget, this);
+	QObject::connect(&dialog, &PickerDialog::fileSelected, [&](const QString& baseName) {
+		m_lineEdit->setText(baseName);
+		m_sound->name = baseName.toStdString();
+		m_sound->volume = widget->volume();
+		m_sound->tempo = widget->tempo();
+		m_sound->balance = widget->balance();
+	});
+	dialog.setDirectoryAndFile(SOUND, m_lineEdit->text());
+	dialog.exec();
+}
+
+void RpgSoundLineEdit::bindSound(lcf::rpg::Sound& sound) {
+	m_sound = &sound;
+	m_lineEdit->setText(QString::fromStdString(sound.name));
+}

--- a/src/ui/common/rpg_audio_lineedit.h
+++ b/src/ui/common/rpg_audio_lineedit.h
@@ -1,0 +1,69 @@
+/*
+ * This file is part of EasyRPG Editor.
+ *
+ * EasyRPG Editor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Editor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Editor. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QObject>
+#include <QWidget>
+
+class QLineEdit;
+class QPushButton;
+class ProjectData;
+
+namespace lcf::rpg {
+	class Music;
+	class Sound;
+}
+
+class RpgAudioLineEdit : public QWidget {
+	Q_OBJECT
+public:
+	explicit RpgAudioLineEdit(QWidget *parent = nullptr);
+
+	void makeModel(ProjectData& project);
+
+	QLineEdit* lineEdit() const;
+
+	virtual void editPressed() = 0;
+
+protected:
+	QLineEdit* m_lineEdit = nullptr;
+	QPushButton* m_editButton = nullptr;
+	ProjectData* m_project = nullptr;
+};
+
+class RpgMusicLineEdit : public RpgAudioLineEdit {
+public:
+	explicit RpgMusicLineEdit(QWidget *parent = nullptr) : RpgAudioLineEdit(parent) {}
+
+	void editPressed() override;
+	void bindMusic(lcf::rpg::Music& music);
+
+private:
+	lcf::rpg::Music* m_music = nullptr;
+};
+
+class RpgSoundLineEdit : public RpgAudioLineEdit {
+public:
+	explicit RpgSoundLineEdit(QWidget *parent = nullptr) : RpgAudioLineEdit(parent) {}
+
+	void editPressed() override;
+	void bindSound(lcf::rpg::Sound& sound);
+
+private:
+	lcf::rpg::Sound* m_sound = nullptr;
+};

--- a/src/ui/database/system_widget.cpp
+++ b/src/ui/database/system_widget.cpp
@@ -18,15 +18,23 @@
 #include "system_widget.h"
 #include "ui_system_widget.h"
 
+#include "src/common/lcf_widget_binding.h"
+
 SystemWidget::SystemWidget(ProjectData& project, QWidget *parent) :
 	QWidget(parent),
 	ui(new Ui::SystemWidget),
-	m_project(project)
-{
+	m_project(project) {
 	ui->setupUi(this);
+
+	ui->lineTitleBgm->makeModel(project);
+	ui->lineCursorSound->makeModel(project);
+
+	auto& sys = project.database().system;
+
+	ui->lineTitleBgm->bindMusic(sys.title_music);
+	ui->lineCursorSound->bindSound(sys.cursor_se);
 }
 
-SystemWidget::~SystemWidget()
-{
+SystemWidget::~SystemWidget() {
 	delete ui;
 }

--- a/src/ui/database/system_widget.ui
+++ b/src/ui/database/system_widget.ui
@@ -188,7 +188,7 @@
     <property name="title">
      <string>Cursor</string>
     </property>
-    <widget class="QLineEdit" name="lineEdit_18">
+    <widget class="RpgSoundLineEdit" name="lineCursorSound">
      <property name="geometry">
       <rect>
        <x>10</x>
@@ -196,19 +196,6 @@
        <width>61</width>
        <height>22</height>
       </rect>
-     </property>
-    </widget>
-    <widget class="QPushButton" name="pushButton_25">
-     <property name="geometry">
-      <rect>
-       <x>70</x>
-       <y>20</y>
-       <width>16</width>
-       <height>21</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>...</string>
      </property>
     </widget>
    </widget>
@@ -717,7 +704,7 @@
     <property name="title">
      <string>Title Screen</string>
     </property>
-    <widget class="QLineEdit" name="lineEdit_9">
+    <widget class="RpgMusicLineEdit" name="lineTitleBgm">
      <property name="geometry">
       <rect>
        <x>10</x>
@@ -725,19 +712,6 @@
        <width>61</width>
        <height>22</height>
       </rect>
-     </property>
-    </widget>
-    <widget class="QPushButton" name="pushButton_16">
-     <property name="geometry">
-      <rect>
-       <x>70</x>
-       <y>20</y>
-       <width>16</width>
-       <height>21</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>...</string>
      </property>
     </widget>
    </widget>
@@ -1225,6 +1199,18 @@
    </widget>
   </widget>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>RpgMusicLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>ui/common/rpg_audio_lineedit.h</header>
+  </customwidget>
+  <customwidget>
+   <class>RpgSoundLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>ui/common/rpg_audio_lineedit.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/src/ui/picker/picker_audio_widget.cpp
+++ b/src/ui/picker/picker_audio_widget.cpp
@@ -1,0 +1,69 @@
+/*
+ * This file is part of EasyRPG Editor.
+ *
+ * EasyRPG Editor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Editor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Editor. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "picker_audio_widget.h"
+#include "ui_picker_audio_widget.h"
+
+#include <lcf/rpg/music.h>
+#include <lcf/rpg/sound.h>
+
+PickerAudioWidget::PickerAudioWidget(const lcf::rpg::Music& music, QWidget *parent) :
+	PickerChildWidget(parent),
+	ui(new Ui::PickerAudioWidget) {
+	ui->setupUi(this);
+
+	ui->sliderFadeIn->setValue(music.fadein);
+	ui->sliderVolume->setValue(music.volume);
+	ui->sliderTempo->setValue(music.tempo);
+	ui->sliderBalance->setValue(music.balance);
+}
+
+PickerAudioWidget::PickerAudioWidget(const lcf::rpg::Sound& sound, QWidget *parent) :
+	PickerChildWidget(parent),
+	ui(new Ui::PickerAudioWidget) {
+	ui->setupUi(this);
+
+	ui->sliderVolume->setValue(sound.volume);
+	ui->sliderTempo->setValue(sound.tempo);
+	ui->sliderBalance->setValue(sound.balance);
+
+	ui->groupFadeIn->hide();
+}
+
+PickerAudioWidget::~PickerAudioWidget() {
+	delete ui;
+}
+
+void PickerAudioWidget::fileChanged(const QString& filename) {
+	m_filename = filename;
+}
+
+int PickerAudioWidget::fadeInTime() const {
+	return ui->sliderFadeIn->value();
+}
+
+int PickerAudioWidget::volume() const {
+	return ui->sliderVolume->value();
+}
+
+int PickerAudioWidget::tempo() const {
+	return ui->sliderTempo->value();
+}
+
+int PickerAudioWidget::balance() const {
+	return ui->sliderBalance->value();
+}

--- a/src/ui/picker/picker_audio_widget.h
+++ b/src/ui/picker/picker_audio_widget.h
@@ -1,0 +1,59 @@
+/*
+ * This file is part of EasyRPG Editor.
+ *
+ * EasyRPG Editor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EasyRPG Editor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EasyRPG Editor. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QWidget>
+
+#include "picker_child_widget.h"
+
+namespace Ui {
+class PickerAudioWidget;
+}
+
+namespace lcf::rpg {
+	class Music;
+	class Sound;
+}
+
+class PickerAudioWidget : public PickerChildWidget {
+	Q_OBJECT
+
+public:
+	enum class Type {
+		Music,
+		Sound
+	};
+
+	explicit PickerAudioWidget(const lcf::rpg::Music& music, QWidget *parent = nullptr);
+	explicit PickerAudioWidget(const lcf::rpg::Sound& sound, QWidget *parent = nullptr);
+	~PickerAudioWidget();
+
+	void fileChanged(const QString&) override;
+
+	int fadeInTime() const;
+	int volume() const;
+	int tempo() const;
+	int balance() const;
+
+private:
+	Ui::PickerAudioWidget *ui;
+
+	Type m_type;
+	QString m_filename;
+};
+

--- a/src/ui/picker/picker_audio_widget.ui
+++ b/src/ui/picker/picker_audio_widget.ui
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>PickerAudioWidget</class>
+ <widget class="QWidget" name="PickerAudioWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>359</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout_5">
+   <item row="0" column="0">
+    <widget class="QGroupBox" name="groupFadeIn">
+     <property name="title">
+      <string>Fade In Time</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="0" column="0">
+       <widget class="RpgSlider" name="sliderFadeIn">
+        <property name="maximum">
+         <number>10</number>
+        </property>
+        <property name="value">
+         <number>0</number>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Volume</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_2">
+      <item row="0" column="0">
+       <widget class="RpgSlider" name="sliderVolume">
+        <property name="maximum">
+         <number>100</number>
+        </property>
+        <property name="value">
+         <number>100</number>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QGroupBox" name="groupBox_2">
+     <property name="title">
+      <string>Tempo</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_3">
+      <item row="0" column="0">
+       <widget class="RpgSlider" name="sliderTempo">
+        <property name="minimum">
+         <number>50</number>
+        </property>
+        <property name="maximum">
+         <number>150</number>
+        </property>
+        <property name="value">
+         <number>100</number>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QGroupBox" name="groupBox_3">
+     <property name="title">
+      <string>Balance</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_4">
+      <item row="0" column="0">
+       <widget class="RpgSlider" name="sliderBalance">
+        <property name="maximum">
+         <number>200</number>
+        </property>
+        <property name="value">
+         <number>100</number>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>RpgSlider</class>
+   <extends>QSlider</extends>
+   <header>ui/common/rpg_slider.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/ui/picker/picker_dialog.cpp
+++ b/src/ui/picker/picker_dialog.cpp
@@ -31,9 +31,21 @@ PickerDialog::PickerDialog(ProjectData &project, FileFinder::FileType file_type,
 		m_project(project),
 		m_file_type(file_type) {
 	ui->setupUi(this);
+	wrappedWidget->setParent(this);
 	ui->wrappedWidget = wrappedWidget;
+	ui->sidebar->insertWidget(1, wrappedWidget);
+
+	ui->filesystemView->setRootIsDecorated(false);
+	ui->filesystemView->setHeaderHidden(true);
+
 	m_model = new QFileSystemModel(this);
 	m_model->setReadOnly(true);
+	ui->filesystemView->setModel(m_model);
+
+	// Hide columns except name
+	for (int i = 1; i <= 3; ++i) {
+		ui->filesystemView->setColumnHidden(i, true);
+	}
 
 	QObject::connect(ui->buttonBox, &QDialogButtonBox::clicked, this, &PickerDialog::buttonClicked);
 
@@ -75,9 +87,10 @@ void PickerDialog::setDirectoryAndFile(const QString &dir, const QString& initia
 	QString path = m_project.project().findDirectory(dir);
 	QString file = m_project.project().findFile(dir, initialFile, m_file_type);
 	m_model->setRootPath(path);
-	ui->filesystemView->setModel(m_model);
 	ui->filesystemView->setRootIndex(m_model->index(path));
-	ui->filesystemView->setCurrentIndex(m_model->index(file));
+
+	QModelIndex index = m_model->index(file);
+	ui->filesystemView->setCurrentIndex(index);
 
 	m_currentFile = file;
 

--- a/src/ui/picker/picker_dialog.ui
+++ b/src/ui/picker/picker_dialog.ui
@@ -6,37 +6,39 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>717</width>
+    <width>720</width>
     <height>537</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Dialog</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_2">
-   <item>
-    <widget class="QSplitter" name="splitter">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <widget class="QTreeView" name="filesystemView"/>
-     <widget class="QWidget" name="layoutWidget">
-      <layout class="QVBoxLayout" name="verticalLayout">
-       <item>
-        <widget class="PixmapGraphicsView" name="graphicsView">
-         <property name="alignment">
-          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="PickerChildWidget" name="wrappedWidget" native="true"/>
-       </item>
-      </layout>
-     </widget>
-    </widget>
+  <layout class="QGridLayout" name="gridLayout" columnstretch="1,0" columnminimumwidth="0,300">
+   <item row="0" column="0">
+    <widget class="QTreeView" name="filesystemView"/>
    </item>
-   <item>
+   <item row="0" column="1">
+    <layout class="QVBoxLayout" name="sidebar">
+     <item>
+      <widget class="PixmapGraphicsView" name="graphicsView">
+       <property name="alignment">
+        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="PickerChildWidget" name="wrappedWidget" native="true">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="1" column="0" colspan="2">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>


### PR DESCRIPTION
This implements a minimalistic picker for Music and Sound:

![music-fs8](https://user-images.githubusercontent.com/1331889/110354696-bbaaf800-8038-11eb-8f9b-451192a226e2.png)

And a LineEdit with a ... button after (similiar to the original editor) for opening that picker.